### PR TITLE
Handle the exception of IndexError when list item access is out of range

### DIFF
--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -94,7 +94,10 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 			if index > 32767: # reserved for future use; ignore
 				name = ""
 			elif index > 257:
-				name = extraNames[index-258]
+				try:
+					name = extraNames[index-258]
+				except IndexError:
+					name = ""
 			else:
 				# fetch names from standard list
 				name = standardGlyphOrder[index]


### PR DESCRIPTION
I am not strong with font tables but this commit is a try to fix small bug and catch case when accessing array item out of range