### PR TITLE
[_n_a_m_e] fix "can't concat bytes to str" error in python 3

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -61,7 +61,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 				name.offset, name.length = done[name.string]
 			else:
 				name.offset, name.length = done[name.string] = len(stringData), len(name.string)
-				stringData = stringData + name.string
+				stringData = bytesjoin([stringData, name.string])
 			data = data + sstruct.pack(nameRecordFormat, name)
 		return data + stringData
 	


### PR DESCRIPTION
I got this error:

    File "C:\Python34\Lib\site-packages\FontTools\fontTools\ttLib\tables\_n_a_m_e.py", line 64, in compile
    stringData = stringData + name.string
    TypeError: can't concat bytes to str

`py23.bytesjoin` should fix it.

Cheers,

Cosimo