### PR TITLE
[xmlWriter] fix UnicodeEncodeError in #232

### DIFF
--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -24,12 +24,10 @@ class XMLWriter(object):
 			self.file = fileOrPath
 
 		# Figure out if writer expects bytes or unicodes
-		try:
-			self.file.write(tounicode(''))
-			self.totype = tounicode
-		except TypeError:
-			self.file.write(b'')
+		if 'b' in self.file.mode:
 			self.totype = tobytes
+		else:
+			self.totype = tounicode
 		self.indentwhite = self.totype(indentwhite)
 		self.newlinestr = self.totype('\n')
 		self.indentlevel = 0

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -24,7 +24,7 @@ class XMLWriter(object):
 			self.file = fileOrPath
 
 		# Figure out if writer expects bytes or unicodes
-		if 'b' in self.file.mode:
+		if isinstance(self.file, StringIO) or 'b' in self.file.mode:
 			self.totype = tobytes
 		else:
 			self.totype = tounicode


### PR DESCRIPTION
in Python 2.x, writing a unicode string to a file that was opened in binary format does not raise TypeError -- unlike Python 3.x.
So under Python 2.x, the xmWriter always uses `tounicode` to coerce bytestrings to unicode strings. However, when xmlWriter tries to write them to the file opened in binary format, Python 2 uses the default system encoding ("ascii") to implicitly convert unicode to bytes, hence it fails (cf. #232).

A better approach to figure out whether writer expects bytes or unicodes could be to test if the file's `mode` attribute contains the string `"b"`, as in "wb", "wb+", "rb", etc.

Cheers,

Cosimo