### PR TITLE
Emit XML even for names whose platform encoding is unsupported

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -130,28 +130,30 @@ class NameRecord(object):
 		return self.getEncoding() in ['utf-16be', 'ucs2be', 'ascii', 'latin1']
 
 	def __str__(self):
-		try:
-			return self.toUnicode()
-		except UnicodeDecodeError:
+		unistr = self.toUnicode()
+		if unistr != None:
+			return unistr
+		else:
 			return str(self.string)
-	
+
 	def isUnicode(self):
 		return (self.platformID == 0 or
 			(self.platformID == 3 and self.platEncID in [0, 1, 10]))
 
 	def toUnicode(self):
-		return tounicode(self.string, encoding=self.getEncoding())
+		encoding = self.getEncoding()
+		if encoding == None:
+			return None
+		try:
+			return tounicode(self.string, encoding=encoding)
+		except UnicodeDecodeError:
+			return None
 
 	def toBytes(self):
 		return tobytes(self.string, encoding=self.getEncoding())
 
 	def toXML(self, writer, ttFont):
-		encoding = self.getEncoding()
-		try:
-			unistr = self.toUnicode()
-		except UnicodeDecodeError:
-			unistr = None
-
+		unistr = self.toUnicode()
 		attrs = [
 				("nameID", self.nameID),
 				("platformID", self.platformID),

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
@@ -1,0 +1,47 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.xmlWriter import XMLWriter
+import unittest
+from ._n_a_m_e import NameRecord
+
+class NameRecordTest(unittest.TestCase):
+
+	def toXML(self, name):
+		writer = XMLWriter(StringIO())
+		name.toXML(writer, ttFont=None)
+		xml = writer.file.getvalue().decode("utf-8").strip()
+		return xml.split(writer.newlinestr.decode("utf-8"))[1:]
+
+	def test_toXML_utf16be(self):
+		name = NameRecord()
+		name.string = "Foo Bold".encode("utf-16be")
+		name.nameID, name.platformID, name.platEncID, name.langID = (111, 0, 2, 7)
+		self.assertEquals([
+                    '<namerecord nameID="111" platformID="0" platEncID="2" langID="0x7">',
+                    '  Foo Bold',
+                    '</namerecord>'
+		], self.toXML(name))
+
+	def test_toXML_macroman(self):
+		name = NameRecord()
+		name.string = "Foo Italic".encode("macroman")
+		name.nameID, name.platformID, name.platEncID, name.langID = (222, 1, 0, 7)
+		self.assertEquals([
+                    '<namerecord nameID="222" platformID="1" platEncID="0" langID="0x7" unicode="True">',
+                    '  Foo Italic',
+                    '</namerecord>'
+		], self.toXML(name))
+
+	def test_toXML_unknownPlatEncID(self):
+		name = NameRecord()
+		name.string = b"B\x8arli"
+		name.nameID, name.platformID, name.platEncID, name.langID = (333, 1, 9876, 7)
+		self.assertEquals([
+                    '<namerecord nameID="333" platformID="1" platEncID="9876" langID="0x7" unicode="False">',
+                    '  B&#138;rli',
+                    '</namerecord>'
+		], self.toXML(name))
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
When dumping the Macintosh Skia font to XML, the TTX tool crashed
with a Python exception. After this change, the font can be dumped
fine. This was caused by a name record with platformID=1 (Macintosh)
and platEncID=2 (Traditional Chinese).