### PR TITLE
Raise UnicodeDecodeError for structurally invalid names

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -154,10 +154,7 @@ class NameRecord(object):
 		encoding = self.getEncoding()
 		if encoding == None:
 			return None
-		try:
-			return tounicode(self.string, encoding=encoding)
-		except UnicodeDecodeError:
-			return None
+		return tounicode(self.string, encoding=encoding)
 
 	def toBytes(self):
 		return tobytes(self.string, encoding=self.getEncoding())

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
@@ -6,6 +6,28 @@ from ._n_a_m_e import NameRecord
 
 class NameRecordTest(unittest.TestCase):
 
+	def makeName(self, text, nameID, platformID, platEncID, langID):
+		name = NameRecord()
+		name.nameID, name.platformID, name.platEncID, name.langID = (nameID, platformID, platEncID, langID)
+		name.string = text.encode(name.getEncoding())
+		return name
+
+	def test_toUnicode_utf16be(self):
+		name = self.makeName("Foo Bold", 111, 0, 2, 7)
+		self.assertEqual("utf-16be", name.getEncoding())
+		self.assertEqual("Foo Bold", name.toUnicode())
+
+	def test_toUnicode_macroman(self):
+		name = self.makeName("Foo Italic", 222, 1, 0, 7)  # MacRoman
+		self.assertEqual("macroman", name.getEncoding())
+		self.assertEqual("Foo Italic", name.toUnicode())
+
+	def test_toUnicode_UnicodeDecodeError(self):
+		name = self.makeName("Foo Bold", 111, 0, 2, 7)
+		self.assertEqual("utf-16be", name.getEncoding())
+		name.string = b"X"  # invalid utf-16be sequence
+		self.assertRaises(UnicodeDecodeError, name.toUnicode)
+
 	def toXML(self, name):
 		writer = XMLWriter(StringIO())
 		name.toXML(writer, ttFont=None)
@@ -13,20 +35,16 @@ class NameRecordTest(unittest.TestCase):
 		return xml.split(writer.newlinestr.decode("utf-8"))[1:]
 
 	def test_toXML_utf16be(self):
-		name = NameRecord()
-		name.string = "Foo Bold".encode("utf-16be")
-		name.nameID, name.platformID, name.platEncID, name.langID = (111, 0, 2, 7)
-		self.assertEquals([
+		name = self.makeName("Foo Bold", 111, 0, 2, 7)
+		self.assertEqual([
                     '<namerecord nameID="111" platformID="0" platEncID="2" langID="0x7">',
                     '  Foo Bold',
                     '</namerecord>'
 		], self.toXML(name))
 
 	def test_toXML_macroman(self):
-		name = NameRecord()
-		name.string = "Foo Italic".encode("macroman")
-		name.nameID, name.platformID, name.platEncID, name.langID = (222, 1, 0, 7)
-		self.assertEquals([
+		name = self.makeName("Foo Italic", 222, 1, 0, 7)  # MacRoman
+		self.assertEqual([
                     '<namerecord nameID="222" platformID="1" platEncID="0" langID="0x7" unicode="True">',
                     '  Foo Italic',
                     '</namerecord>'
@@ -36,12 +54,12 @@ class NameRecordTest(unittest.TestCase):
 		name = NameRecord()
 		name.string = b"B\x8arli"
 		name.nameID, name.platformID, name.platEncID, name.langID = (333, 1, 9876, 7)
-		self.assertEquals([
+		self.assertEqual([
                     '<namerecord nameID="333" platformID="1" platEncID="9876" langID="0x7" unicode="False">',
                     '  B&#138;rli',
                     '</namerecord>'
 		], self.toXML(name))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This will make it impossible to process fonts with super-broken
name tables. But we do not handle arbitrary broken fonts anyway,
so this is arguably better than silently ignoring junk content.
Resolves a review comment in #235.

In the unit test, replace calls of deprecated unittest.assertEquals()
by calls of unittest.assertEqual().