### PR TITLE
[bezierTools] fix bug in splitLine function

### DIFF
--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -80,11 +80,15 @@ def splitLine(pt1, pt2, where, isHorizontal):
         >>> printSegments(splitLine((0, 0), (100, 100), 100, True))
         ((0, 0), (100, 100))
         >>> printSegments(splitLine((0, 0), (100, 100), 0, True))
-        ((0, 0), (0, 0))
         ((0, 0), (100, 100))
         >>> printSegments(splitLine((0, 0), (100, 100), 0, False))
-        ((0, 0), (0, 0))
         ((0, 0), (100, 100))
+        >>> printSegments(splitLine((100, 0), (0, 0), 50, False))
+        ((100, 0), (50, 0))
+        ((50, 0), (0, 0))
+        >>> printSegments(splitLine((0, 100), (0, 0), 50, True))
+        ((0, 100), (0, 50))
+        ((0, 50), (0, 0))
     """
     pt1x, pt1y = pt1
     pt2x, pt2y = pt2
@@ -95,11 +99,12 @@ def splitLine(pt1, pt2, where, isHorizontal):
     bx = pt1x
     by = pt1y
 
-    if ax == 0:
-        return [(pt1, pt2)]
+    a = (ax, ay)[isHorizontal]
 
-    t = (where - (bx, by)[isHorizontal]) / ax
-    if 0 <= t < 1:
+    if a == 0:
+        return [(pt1, pt2)]
+    t = (where - (bx, by)[isHorizontal]) / a
+    if 0 < t < 1:
         midPt = ax * t + bx, ay * t + by
         return [(pt1, midPt), (midPt, pt2)]
     else:

--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -80,8 +80,10 @@ def splitLine(pt1, pt2, where, isHorizontal):
         >>> printSegments(splitLine((0, 0), (100, 100), 100, True))
         ((0, 0), (100, 100))
         >>> printSegments(splitLine((0, 0), (100, 100), 0, True))
+        ((0, 0), (0, 0))
         ((0, 0), (100, 100))
         >>> printSegments(splitLine((0, 0), (100, 100), 0, False))
+        ((0, 0), (0, 0))
         ((0, 0), (100, 100))
         >>> printSegments(splitLine((100, 0), (0, 0), 50, False))
         ((100, 0), (50, 0))
@@ -104,7 +106,7 @@ def splitLine(pt1, pt2, where, isHorizontal):
     if a == 0:
         return [(pt1, pt2)]
     t = (where - (bx, by)[isHorizontal]) / a
-    if 0 < t < 1:
+    if 0 <= t < 1:
         midPt = ax * t + bx, ay * t + by
         return [(pt1, midPt), (midPt, pt2)]
     else:


### PR DESCRIPTION
https://github.com/behdad/fonttools/issues/241

good catch @typemytype!

Indeed the function is not splitting the line when the two points are vertically aligned (same x coordinate) and `isHorizontal=True`.

While looking at this, I also noticed another inconsistency in the code.
When the value `t == 1`, i.e. when the `where` coordinate falls on `pt2`, the line is not split -- which is ok.
However, if `t == 0`, i.e. when `where` is on top of `pt1`, then a zero-length segment is created, with two overlapping points, which I think doesn't make sense.
 
Here's my fix. Please let me know what you think.
All best,

Cosimo