### PR TITLE
[macCreatorType] return correct creator/type on Python 2.7

### DIFF
--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -16,9 +16,10 @@ def _reverseString(s):
 def getMacCreatorAndType(path):
 	if MacOS is not None:
 		fileCreator, fileType = MacOS.GetCreatorAndType(path)
-		if sys.byteorder == "little":
+		if sys.version_info[:2] < (2, 7) and sys.byteorder == "little":
 			# work around bug in MacOS.GetCreatorAndType() on intel:
 			# http://bugs.python.org/issue1594
+			# (fixed with Python 2.7)
 			fileCreator = _reverseString(fileCreator)
 			fileType = _reverseString(fileType)
 		return fileCreator, fileType


### PR DESCRIPTION
the function "getMacCreatorAndType" contains a workaround to address a bug in `GetCreatorAndType` function from the `MacOS` module.
On the Intel platform with 'little endian' byte order, the function would return strings in reverse order.

A comment in fontTools source code links to a bug report made by Just himself on the Python issue tracker (http://bugs.python.org/issue1594). They say the bug was fixed in a later python revision (this was 2009!).

I found out that the bug is still there until Python version 2.6.9, but it was finally fixed with Python 2.7.0 (I had to install both and test them on my mac).

The current patch will limit the workaround to Python versions less than 2.7 (i.e. basically Python 2.6.x, since earlier versions are no longer supported either).

The patch seem to fix the issue https://github.com/behdad/fonttools/issues/221 reported by @adrientetar.

I think there's no need to use Appkit to get the mac's file creator and type (they use that in [extractor](https://github.com/anthrotype/extractor/blob/master/Lib/extractor/formats/type1.py)). The `MacOS.getMacCreatorAndType` still works fine, even on on 64 bit architecture -- provided one disables the workaround which is no longer required for Python 2.7.

I can now read LWFN Type1 fonts with t1Lib.py and save them as PFB, or even feed a TrueType resource-fork suitcase to TTX, and dump it to XML as usual.
I'm using Homebrew Python 2.7.9 on Mavericks.


