### PR TITLE
[otBase] fix unhashable types in python 3

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -683,6 +683,7 @@ class BaseTable(object):
 
 	def __ne__(self, other):
 		return not self.__eq__(other)
+
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
@@ -691,6 +692,8 @@ class BaseTable(object):
 		other.ensureDecompiled()
 
 		return self.__dict__ == other.__dict__
+
+	__hash__ = object.__hash__
 
 
 class FormatSwitchingBaseTable(BaseTable):


### PR DESCRIPTION
after commit c4d0400, the pyftsubset raises a `Type Error` when running it under Python 3 (v3.4.3 on Windows).

The problem has to to with a change occurred between Python 2 and 3, as explained in the Python 3 documentation of `object.__hash__`:

<https://docs.python.org/3.1/reference/datamodel.html?highlight=hash#object.%5F%5Fhash%5F%5F> 

>  If a class [...] defines __eq__() but not __hash__(), its instances will not be usable as items in hashable collections. [...] If a class that overrides __eq__() needs to retain the implementation of __hash__() from a parent class, the interpreter must be told this explicitly by setting __hash__ = <ParentClass>.__hash__

So I explicitly set the method `__hash__ = object.__hash__` inside the `otBase.BaseTable` class, and now the subsetter runs successfully.

However, I'm not 100% sure this is enough to fix the issue.

Maybe we need to implement a better hashing method that is consistent with the current `BaseTable.__eq__` method (the latter compares the inner __dict__ for equality)?

As the doc explains, the reason why in Python 3 they decided to enforce such "unhashability" of user-defined types which override `__eq__` without explicitly also overriding `__hash__`, is that:

> the implementation of hashable collections requires that a key’s hash value is immutable.

If a class defines mutable objects (and I presume BaseTable class and its subclasses do define mutable objects), then:

> if the object’s hash value changes, it will be in the wrong hash bucket

Appended below is the full traceback:

    Traceback (most recent call last):
      File "c:/UsersLocal/cosimo.lupo/Documents/venv/sfntly3/Scripts/pyftsubset", line 6, in <module>
        exec(compile(open(__file__).read(), __file__, 'exec'))
      File "C:\UsersLocal\cosimo.lupo\Documents\GitHub\fonttools\Tools\pyftsubset", line 6, in <module>
        subset.main(sys.argv[1:])
      File "c:\userslocal\cosimo.lupo\documents\github\fonttools\lib\fontTools\subset.py", line 2744, in main
        subsetter.subset(font)
      File "c:\userslocal\cosimo.lupo\documents\github\fonttools\lib\fontTools\subset.py", line 2529, in subset
        self._closure_glyphs(font)
      File "c:\userslocal\cosimo.lupo\documents\github\fonttools\lib\fontTools\subset.py", line 2458, in _closure_glyphs
        font['GSUB'].closure_glyphs(self)
      File "c:\userslocal\cosimo.lupo\documents\github\fonttools\lib\fontTools\subset.py", line 1318, in closure_glyphs
        self.table.LookupList.Lookup[i].closure_glyphs(s)
      File "c:\userslocal\cosimo.lupo\documents\github\fonttools\lib\fontTools\subset.py", line 1112, in closure_glyphs
        if self in s._doneLookups:
    TypeError: unhashable type: 'Lookup'
