### PR TITLE
[GX] Support 'gvar' table

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -56,7 +56,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		axisTags = [axis.AxisTag for axis in ttFont["fvar"].table.VariationAxis]
 
 		sharedCoords = self.compileSharedCoords_(ttFont, axisTags)
-		sharedCoordIndices = dict([(sharedCoords[i], i) for i in xrange(len(sharedCoords))])
+		sharedCoordIndices = dict([(sharedCoords[i], i) for i in range(len(sharedCoords))])
 		sharedCoordSize = sum([len(c) for c in sharedCoords])
 
 		compiledGlyphs = self.compileGlyphs_(ttFont, axisTags, sharedCoordIndices)
@@ -145,7 +145,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		# (a) each tuple supplies its own private set of points;
 		# (b) all tuples refer to a shared set of points, which consists of
 		#     "every control point in the glyph".
-		allPoints = set(xrange(numPointsInGlyph))
+		allPoints = set(range(numPointsInGlyph))
 		tuples = []
 		data = []
 		someTuplesSharePoints = False
@@ -184,7 +184,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 						 format=(self.flags & 1), glyphCount=self.glyphCount)
 		sharedCoords = self.decompileSharedCoords_(axisTags, data)
 		self.variations = {}
-		for i in xrange(self.glyphCount):
+		for i in range(self.glyphCount):
 			glyphName = glyphs[i]
 			glyph = ttFont["glyf"][glyphName]
 			numPoints = self.getNumPoints_(glyph)
@@ -229,7 +229,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		of the 'gvar' header.
 		"""
 		assert len(offsets) >= 2
-		for i in xrange(1, len(offsets)):
+		for i in range(1, len(offsets)):
 			assert offsets[i - 1] <= offsets[i]
 		if max(offsets) <= 0xffff * 2:
 			packed = array.array(b"H", [n >> 1 for n in offsets])
@@ -253,7 +253,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			sharedPoints, dataPos = GlyphVariation.decompilePoints_(numPoints, data, dataPos)
 		else:
 			sharedPoints = []
-		for i in xrange(flags & TUPLE_COUNT_MASK):
+		for i in range(flags & TUPLE_COUNT_MASK):
 			dataSize, flags = struct.unpack(b">HH", data[pos:pos+4])
 			tupleSize = GlyphVariation.getTupleSize_(flags, numAxes)
 			tuple = data[pos : pos + tupleSize]
@@ -366,7 +366,7 @@ class GlyphVariation:
 
 	def getUsedPoints(self):
 		result = set()
-		for p in xrange(len(self.coordinates)):
+		for p in range(len(self.coordinates)):
 			if self.coordinates[p] != (0, 0):
 				result.add(p)
 		return result
@@ -398,7 +398,7 @@ class GlyphVariation:
 							 min=minValue, max=maxValue)
 				writer.newline()
 		wrote_any_points = False
-		for i in xrange(len(self.coordinates)):
+		for i in range(len(self.coordinates)):
 			x, y = self.coordinates[i]
 			if x != 0 or y != 0:
 				writer.simpletag("delta", pt=i, x=x, y=y)
@@ -489,7 +489,7 @@ class GlyphVariation:
 	def decompileCoords_(axisTags, numCoords, data, offset):
 		result = []
 		pos = offset
-		for i in xrange(numCoords):
+		for i in range(numCoords):
 			coord, pos = GlyphVariation.decompileCoord_(axisTags, data, pos)
 			result.append(coord)
 		return result, pos
@@ -561,12 +561,12 @@ class GlyphVariation:
 			numPointsInRun = (runHeader & POINT_RUN_COUNT_MASK) + 1
 			point = 0
 			if (runHeader & POINTS_ARE_WORDS) == 0:
-				for i in xrange(numPointsInRun):
+				for i in range(numPointsInRun):
 					point += ord(data[pos])
 					pos += 1
 					result.append(point)
 			else:
-				for i in xrange(numPointsInRun):
+				for i in range(numPointsInRun):
 					point += struct.unpack(">H", data[pos:pos+2])[0]
 					pos += 2
 					result.append(point)
@@ -644,7 +644,7 @@ class GlyphVariation:
 			runLength += 1
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(runLength - 1))
-		for i in xrange(offset, pos):
+		for i in range(offset, pos):
 			stream.write(struct.pack('b', deltas[i]))
 		return pos
 
@@ -678,7 +678,7 @@ class GlyphVariation:
 			runLength += 1
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(DELTAS_ARE_WORDS | (runLength - 1)))
-		for i in xrange(offset, pos):
+		for i in range(offset, pos):
 			stream.write(struct.pack('>h', deltas[i]))
 		return pos
 
@@ -694,11 +694,11 @@ class GlyphVariation:
 			if (runHeader & DELTAS_ARE_ZERO) != 0:
 				result.extend([0] * numDeltasInRun)
 			elif (runHeader & DELTAS_ARE_WORDS) != 0:
-				for i in xrange(numDeltasInRun):
+				for i in range(numDeltasInRun):
 					result.append(struct.unpack(">h", data[pos:pos+2])[0])
 					pos += 2
 			else:
-				for i in xrange(numDeltasInRun):
+				for i in range(numDeltasInRun):
 					result.append(struct.unpack(">b", data[pos])[0])
 					pos += 1
 		assert len(result) == numDeltas

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -74,21 +74,19 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	def decompileSharedCoords_(self, axisTags, data):
 		result = []
 		pos = self.offsetToCoord
-		stride = len(axisTags) * 2
 		for i in xrange(self.sharedCoordCount):
-			coord = self.decompileCoord_(axisTags, data[pos:pos+stride])
+			coord, pos = self.decompileCoord_(axisTags, data, pos)
 			result.append(coord)
-			pos += stride
 		return result
 
 	@staticmethod
-	def decompileCoord_(axisTags, data):
+	def decompileCoord_(axisTags, data, offset):
 		coord = {}
-		pos = 0
+		pos = offset
 		for axis in axisTags:
 			coord[axis] = fixedToFloat(struct.unpack(b">h", data[pos:pos+2])[0], 14)
 			pos += 2
-		return coord
+		return coord, pos
 
 	@staticmethod
 	def decompileOffsets_(data, format, glyphCount):
@@ -175,14 +173,11 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		if (flags & EMBEDDED_TUPLE_COORD) == 0:
 			coord = sharedCoords[flags & TUPLE_INDEX_MASK]
 		else:
-			coord = table__g_v_a_r.decompileCoord_(axisTags, data[pos:pos+coordSize])
-			pos += coordSize
+			coord, pos = table__g_v_a_r.decompileCoord_(axisTags, data, pos)
 		minCoord = maxCoord = coord
 		if (flags & INTERMEDIATE_TUPLE) != 0:
-			minCoord = table__g_v_a_r.decompileCoord_(axisTags, data[pos:pos+coordSize])
-			pos += coordSize
-			maxCoord = table__g_v_a_r.decompileCoord_(axisTags, data[pos:pos+coordSize])
-			pos += coordSize
+			minCoord, pos = table__g_v_a_r.decompileCoord_(axisTags, data, pos)
+			maxCoord, pos = table__g_v_a_r.decompileCoord_(axisTags, data, pos)
 		axes = {}
 		for axis in axisTags:
 			coords = minCoord[axis], coord[axis], maxCoord[axis]

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -163,7 +163,10 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		for gvar in variations:
 			privateTuple, privateData = gvar.compile(axisTags, sharedCoordIndices, sharedPoints=None)
 			sharedTuple, sharedData = gvar.compile(axisTags, sharedCoordIndices, sharedPoints=allPoints)
-			if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
+			# TODO: If we use shared points, Apple MacOS X 10.9.5 cannot display our fonts.
+			# This is probably a problem with our code; find the problem and fix it.
+			#if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
+			if False:
 				tuples.append(sharedTuple)
 				data.append(sharedData)
 				someTuplesSharePoints = True

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -106,17 +106,6 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			result.append(self.compileGlyph_(glyphName, numPointsInGlyph, axisTags, sharedCoordIndices))
 		return result
 
-	# TODO: Remove this once the code works.
-	@staticmethod
-	def visualizePoints_(points):
-		result = []
-		for p in xrange(max(points) + 1):
-			if p in points:
-				result.append("*")
-			else:
-				result.append("_")
-		return ''.join(result)
-
 	def compileGlyph_(self, glyphName, numPointsInGlyph, axisTags, sharedCoordIndices):
 		variations = self.variations.get(glyphName, [])
 		# Omit variations that have no user-visible impact because their deltas

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -111,7 +111,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	def compileOffsets_(offsets):
 		"""Packs a list of offsets into a 'gvar' offset table.
 
-		Returns a pair (bytestring, flag). Bytestring is the
+		Returns a pair (bytestring, format). Bytestring is the
 		packed offset table. Format indicates whether the table
 		uses short (format=0) or long (format=1) integers.
 		The returned format should get packed into the flags field

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -45,7 +45,6 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	dependencies = ["fvar", "glyf"]
 
 	def decompile(self, data, ttFont):
-		data = buffer(data)  # We do a lot of slicing; no need to copy all those sub-buffers.
 		axisTags = [axis.AxisTag for axis in ttFont['fvar'].table.VariationAxis]
 		glyphs = ttFont.getGlyphOrder()
 		sstruct.unpack(GVAR_HEADER_FORMAT, data[0:GVAR_HEADER_SIZE], self)
@@ -64,7 +63,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 				# Empty glyphs (eg. space, nonmarkingreturn) have no "coordinates" attribute.
 				numPoints = len(getattr(glyph, "coordinates", [])) + 4
 			gvarData = data[self.offsetToData + offsets[i] : self.offsetToData + offsets[i + 1]]
-			self.variations[glyphName] = self.decompileVariations_(numPoints, sharedCoords, axisTags, gvarData)
+			self.variations[glyphName] = self.decompileTuples_(numPoints, sharedCoords, axisTags, gvarData)
 
 	def decompileSharedCoords_(self, axisTags, data):
 		result = []
@@ -114,8 +113,9 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 
 		Returns a pair (bytestring, flag). Bytestring is the
 		packed offset table. Format indicates whether the table
-		uses short (0) or long (1) integers, and should be stored
-		into the flags field of the 'gvar' header.
+		uses short (format=0) or long (format=1) integers.
+		The returned format should get packed into the flags field
+		of the 'gvar' header.
 		"""
 		assert len(offsets) >= 2
 		for i in xrange(1, len(offsets)):
@@ -130,35 +130,41 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			packed.byteswap()
 		return (packed.tostring(), format)
 
-	def decompileVariations_(self, numPoints, sharedCoords, axisTags, data):
+	def decompileTuples_(self, numPoints, sharedCoords, axisTags, data):
 		if len(data) < 4:
 			return []
 		tuples = []
-		tupleCount, offsetToData = struct.unpack(b">HH", data[:4])
-		tuplesSharePointNumbers = (tupleCount & TUPLES_SHARE_POINT_NUMBERS) != 0
-		tupleCount = tupleCount & TUPLE_COUNT_MASK
-		tuplePos = 4
+		flags, offsetToData = struct.unpack(b">HH", data[:4])
+		tuplesSharePointNumbers = (flags & TUPLES_SHARE_POINT_NUMBERS) != 0
+		assert not tuplesSharePointNumbers  # TODO: Implement.
+		pos = 4
 		dataPos = offsetToData
-		for i in xrange(tupleCount):
-			tupleSize, tupleIndex = struct.unpack(b">HH", data[tuplePos:tuplePos+4])
-			if (tupleIndex & EMBEDDED_TUPLE_COORD) != 0:
-				coord = self.decompileCoord_(axisTags, data[tuplePos+4:])
-			else:
-				coord = sharedCoords[tupleIndex & TUPLE_INDEX_MASK].copy()
-			gvar = GlyphVariation(coord)
-			tuples.append(gvar)
-			tuplePos += self.getTupleSize_(tupleIndex, self.axisCount)
-		return []
+		for i in xrange(flags & TUPLE_COUNT_MASK):
+			dataSize, flags = struct.unpack(b">HH", data[pos:pos+4])
+			tupleSize = self.getTupleSize_(flags, self.axisCount)
+			tuple = data[pos : pos + tupleSize]
+			tupleData = data[dataPos : dataPos + dataSize]
+			tuples.append(self.decompileTuple_(numPoints, sharedCoords, axisTags, tuple, tupleData))
+			pos += tupleSize
+			dataPos += dataSize
+		return tuples
 
 	@staticmethod
-	def getTupleSize_(tupleIndex, axisCount):
-		"""Returns the byte size of a tuple given the value of its tupleIndex field."""
+	def getTupleSize_(flags, axisCount):
 		size = 4
-		if (tupleIndex & EMBEDDED_TUPLE_COORD) != 0:
+		if (flags & EMBEDDED_TUPLE_COORD) != 0:
 			size += axisCount * 2
-		if (tupleIndex & INTERMEDIATE_TUPLE) != 0:
+		if (flags & INTERMEDIATE_TUPLE) != 0:
 			size += axisCount * 4
 		return size
+
+	@staticmethod
+	def decompileTuple_(numPoints, sharedCoords, axisTags, data, tupleData):
+		flags = struct.unpack(b">H", data[2:4])[0]
+		print('***** tuple; flags:%04x' % flags)
+		print('data: %s' % ' '.join([x.encode('hex') for x in data]))
+		print('tupleData: %s' % ' '.join([x.encode('hex') for x in tupleData]))
+		return "TODO"
 
 	@staticmethod
 	def decompileDeltas_(numDeltas, data):
@@ -189,9 +195,6 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		writer.newline()
 
 
-POINTS_ARE_WORDS = 0x80
-POINT_RUN_COUNT_MASK = 0x7F
-
 class GlyphVariation:
 	def __init__(self, axes):
 		self.axes = axes
@@ -200,28 +203,3 @@ class GlyphVariation:
 	def __repr__(self):
 		axes = ','.join(sorted(['%s=%s' % (name, value) for (name, value) in self.axes.items()]))
 		return '<GlyphVariation %s>' % axes
-
-	@staticmethod
-	def decompilePoints(data):
-		pos = 0
-		return None
-
-	#def decompilePackedPoints(self, data):
-	#	pos = 0
-	#	numPoints = ord(data[pos])
-	#	if numPoints >= 0x80:
-	#		pos += 1
-	#		numPoints = (numPoints & 0x7f) << 8 | ord(data[pos])
-	#	pos += 1
-	#	points = []
-	#	if numPoints == 0:
-	#		return (points, data[pos:])
-	#	i = 0
-	#	while i < numPoints:
-	#		controlByte = ord(data[pos])
-	#		if (controlByte & 0x80) != 0:
-	#			
-	#			pos += 1
-	#			numPointsInRun = (numPointsInRun & 0x7f) << 8 | ord(data[pos])
-	#		print('********************** numPointsInRun: %d' % numPointsInRun)
-	#		break

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -123,6 +123,32 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		if len(variations) == 0:
 			return b""
 
+		# TODO: Find a heuristic for using shared versus private point lists.
+		#
+		# The variation tuples modify a set of points. To indicate which points
+		# it affects, a single tuple can either refer to a shared set of points,
+		# or the tuple can supply its private point numbers. Because the impact
+		# of sharing can be positive (no need for private point list) or negative
+		# (need to supply 0,0 deltas for unused points), it is not obvious how
+		# to determine which tuples should take their points from the shared
+		# pool versus have their own. Perhaps we should resort to brute force,
+		# and try all combinations? However, if a glyph has n variation tuples,
+		# we would need to try 2^n combinations (because each tuple may or may not
+		# be part of the shared set). How many variations tuples do glyphs have?
+		#
+		#   Skia.ttf: {3: 1, 5: 11, 6: 41, 7: 62, 8: 387, 13: 1, 14: 3}
+		#   JamRegular.ttf: {3: 13, 4: 122, 5: 1, 7: 4, 8: 1, 9: 1, 10: 1}
+		#   BuffaloGalRegular.ttf: {1: 16, 2: 13, 4: 2, 5: 4, 6: 19, 7: 1, 8: 3, 9: 18}
+		#
+		# Reading example: In Skia.ttf, 41 glyphs have 6 variation tuples.
+		# Is it even worth optimizing? If we never use a shared point list,
+		# the private lists will consume 112K for Skia, 5K for BuffaloGalRegular,
+		# and 15K for JamRegular. If we always use a shared point list,
+		# the shared lists will consume 16K for Skia, 3K for BuffaloGalRegular,
+		# and 10K for JamRegular. However, in the latter case the delta arrays
+		# will become larger, but I haven't yet measured by how much. From
+		# gut feeling (which may be wrong), the optimum is to share some but
+		# not all points; however, then we would need to try all combinations.
 		usedPoints = [gvar.getUsedPoints() for gvar in variations]
 		usedPointsUnion = set.union(*usedPoints)
 		print('-------------------- %s %s' % (glyph, len(usedPoints)))

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -232,10 +232,10 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		for i in range(1, len(offsets)):
 			assert offsets[i - 1] <= offsets[i]
 		if max(offsets) <= 0xffff * 2:
-			packed = array.array(b"H", [n >> 1 for n in offsets])
+			packed = array.array("H", [n >> 1 for n in offsets])
 			format = 0
 		else:
-			packed = array.array(b"I", offsets)
+			packed = array.array("I", offsets)
 			format = 1
 		if sys.byteorder != "big":
 			packed.byteswap()
@@ -246,7 +246,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			return []
 		numAxes = len(axisTags)
 		tuples = []
-		flags, offsetToData = struct.unpack(b">HH", data[:4])
+		flags, offsetToData = struct.unpack(">HH", data[:4])
 		pos = 4
 		dataPos = offsetToData
 		if (flags & TUPLES_SHARE_POINT_NUMBERS) != 0:
@@ -254,7 +254,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		else:
 			sharedPoints = []
 		for i in range(flags & TUPLE_COUNT_MASK):
-			dataSize, flags = struct.unpack(b">HH", data[pos:pos+4])
+			dataSize, flags = struct.unpack(">HH", data[pos:pos+4])
 			tupleSize = GlyphVariation.getTupleSize_(flags, numAxes)
 			tuple = data[pos : pos + tupleSize]
 			tupleData = data[dataPos : dataPos + dataSize]
@@ -265,7 +265,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 
 	@staticmethod
 	def decompileTuple_(numPoints, sharedCoords, sharedPoints, axisTags, data, tupleData):
-		flags = struct.unpack(b">H", data[2:4])[0]
+		flags = struct.unpack(">H", data[2:4])[0]
 
 		pos = 4
 		coordSize = len(axisTags) * 2
@@ -299,7 +299,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	def computeMinMaxCoord_(coord):
 		minCoord = {}
 		maxCoord = {}
-		for (axis, value) in coord.iteritems():
+		for (axis, value) in coord.items():
 			minCoord[axis] = min(value, 0.0)  # -0.3 --> -0.3; 0.7 --> 0.0
 			maxCoord[axis] = max(value, 0.0)  # -0.3 -->  0.0; 0.7 --> 0.7
 		return (minCoord, maxCoord)
@@ -429,7 +429,7 @@ class GlyphVariation:
 		tuple = []
 
 		coord = self.compileCoord(axisTags)
-		if sharedCoordIndices.has_key(coord):
+		if coord in sharedCoordIndices:
 			flags = sharedCoordIndices[coord]
 		else:
 			flags = EMBEDDED_TUPLE_COORD
@@ -454,7 +454,7 @@ class GlyphVariation:
 		result = []
 		for axis in axisTags:
 			minValue, value, maxValue = self.axes.get(axis, (0.0, 0.0, 0.0))
-			result.append(struct.pack(b">h", floatToFixed(value, 14)))
+			result.append(struct.pack(">h", floatToFixed(value, 14)))
 		return bytesjoin(result)
 
 	def compileIntermediateCoord(self, axisTags):
@@ -472,8 +472,8 @@ class GlyphVariation:
 		maxCoords = []
 		for axis in axisTags:
 			minValue, value, maxValue = self.axes.get(axis, (0.0, 0.0, 0.0))
-			minCoords.append(struct.pack(b">h", floatToFixed(minValue, 14)))
-			maxCoords.append(struct.pack(b">h", floatToFixed(maxValue, 14)))
+			minCoords.append(struct.pack(">h", floatToFixed(minValue, 14)))
+			maxCoords.append(struct.pack(">h", floatToFixed(maxValue, 14)))
 		return bytesjoin(minCoords + maxCoords)
 
 	@staticmethod
@@ -481,7 +481,7 @@ class GlyphVariation:
 		coord = {}
 		pos = offset
 		for axis in axisTags:
-			coord[axis] = fixedToFloat(struct.unpack(b">h", data[pos:pos+2])[0], 14)
+			coord[axis] = fixedToFloat(struct.unpack(">h", data[pos:pos+2])[0], 14)
 			pos += 2
 		return coord, pos
 
@@ -699,7 +699,7 @@ class GlyphVariation:
 					pos += 2
 			else:
 				for i in range(numDeltasInRun):
-					result.append(struct.unpack(">b", data[pos])[0])
+					result.append(struct.unpack(">b", data[pos:pos+1])[0])
 					pos += 1
 		assert len(result) == numDeltas
 		return (result, pos)

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -1,0 +1,236 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat
+from fontTools.misc.textTools import safeEval
+from . import DefaultTable
+import array
+import sys
+import struct
+
+# Apple's documentation of 'gvar':
+# https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gvar.html
+#
+# TrueType source code for parsing 'gvar':
+# http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/src/truetype/ttgxvar.c
+
+gvarHeaderFormat = b"""
+	> # big endian
+	version:		H
+	reserved:		H
+	axisCount:		H
+	sharedCoordCount:	H
+	offsetToCoord:		I
+	glyphCount:		H
+	flags:			H
+	offsetToData:		I
+"""
+
+gvarItemFormat = b"""
+	> # big endian
+	tupleCount:	H
+	offsetToData:	H
+"""
+
+GVAR_HEADER_SIZE = sstruct.calcsize(gvarHeaderFormat)
+gvarItemSize = sstruct.calcsize(gvarItemFormat)
+
+TUPLES_SHARE_POINT_NUMBERS = 0x8000
+TUPLE_COUNT_MASK = 0x0fff
+
+EMBEDDED_TUPLE_COORD = 0x8000
+INTERMEDIATE_TUPLE = 0x4000
+PRIVATE_POINT_NUMBERS = 0x2000
+TUPLE_INDEX_MASK = 0x0fff
+
+class table__g_v_a_r(DefaultTable.DefaultTable):
+
+	dependencies = ["fvar", "glyf"]
+
+	def decompile(self, data, ttFont):
+		axisTags = [axis.AxisTag for axis in ttFont['fvar'].table.VariationAxis]
+		glyphs = ttFont.getGlyphOrder()
+		sstruct.unpack(gvarHeaderFormat, data[0:GVAR_HEADER_SIZE], self)
+		assert len(glyphs) == self.glyphCount
+		assert len(axisTags) == self.axisCount
+		offsets = self.decompileOffsets_(data)
+		sharedCoords = self.decompileSharedCoords_(axisTags, data)
+		self.variations = {}
+		for i in range(self.glyphCount):
+			glyphName = glyphs[i]
+			glyph = ttFont["glyf"][glyphName]
+			if glyph.isComposite():
+				numPoints = len(glyph.components) + 4
+			else:
+				# Empty glyphs (eg. space, nonmarkingreturn) have no "coordinates" attribute.
+				numPoints = len(getattr(glyph, "coordinates", [])) + 4
+			gvarData = data[self.offsetToData + offsets[i] : self.offsetToData + offsets[i + 1]]
+			self.variations[glyphName] = self.decompileVariations_(numPoints, sharedCoords, axisTags, gvarData)
+
+	def decompileSharedCoords_(self, axisTags, data):
+		result = []
+		pos = self.offsetToCoord
+		stride = len(axisTags) * 2
+		for i in range(self.sharedCoordCount):
+			coord = self.decompileCoord_(axisTags, data[pos:pos+stride])
+			result.append(coord)
+			pos += stride
+		return result
+
+	@staticmethod
+	def decompileCoord_(axisTags, data):
+		coord = {}
+		pos = 0
+		for axis in axisTags:
+			coord[axis] = fixedToFloat(struct.unpack(b">h", data[pos:pos+2])[0], 14)
+			pos += 2
+		return coord
+
+	def decompileOffsets_(self, data):
+		if (self.flags & 1) == 0:
+			# Short format: array of UInt16
+			offsets = array.array("H")
+			offsetsSize = (self.glyphCount + 1) * 2
+		else:
+			# Long format: array of UInt32
+			offsets = array.array("I")
+			offsetsSize = (self.glyphCount + 1) * 4
+		offsetsData = data[GVAR_HEADER_SIZE : GVAR_HEADER_SIZE + offsetsSize]
+		offsets.fromstring(offsetsData)
+		if sys.byteorder != "big":
+			offsets.byteswap()
+
+		# In the short format, offsets need to be multiplied by 2.
+		# This is not documented in Apple's TrueType specification,
+		# but can be inferred from the FreeType implementation, and
+		# we could verify it with two sample GX fonts.
+		if (self.flags & 1) == 0:
+			offsets = [off * 2 for off in offsets]
+
+		return offsets
+
+	def decompileVariations_(self, numPoints, sharedCoords, axisTags, data):
+		if len(data) < 4:
+			return []
+		tupleCount, offsetToData = struct.unpack(b">HH", data[:4])
+		tuplesSharePointNumbers = (tupleCount & TUPLES_SHARE_POINT_NUMBERS) != 0
+		tupleCount = tupleCount & TUPLE_COUNT_MASK
+		tuplePos = 4
+		dataPos = offsetToData
+		for i in range(tupleCount):
+			tupleSize, tupleIndex = struct.unpack(b">HH", data[tuplePos:tuplePos+4])
+			if (tupleIndex & EMBEDDED_TUPLE_COORD) != 0:
+				print('****** %d ' % (tupleIndex & TUPLE_INDEX_MASK))
+				print(' '.join(x.encode('hex') for x in data))
+				coord = self.decompileCoord_(axisTags, data[tuplePos+4:])
+			else:
+				pass #coord = sharedCoords[tupleIndex & TUPLE_INDEX_MASK].copy()
+			tuplePos += self.getTupleSize(tupleIndex)
+		return []
+
+									     
+									     
+	# -------------------- from here comes junk ---------------------------------------------------
+	# TODO: Remove glyphName argument, it is just for debugging.
+	def OBSOLETE_decompileGlyphVariation(self, glyphName, sharedCoords, data):
+		tracing = False or (glyphName == 'I')
+		if tracing: print(' '.join(x.encode('hex') for x in data))
+		if len(data) == 0:
+			return []
+		result = []
+		tupleCount, offsetToData = struct.unpack(b">HH", data[:4])
+		tuplesSharePointNumbers = (tupleCount & 0x8000) != 0
+		tupleCount = tupleCount & 0xfff
+		pos = 4
+		dataPos = offsetToData
+		if tracing: print('tuplesSharePointNumbers=%s' % tuplesSharePointNumbers)
+		for i in range(tupleCount):
+			tupleSize, tupleIndex = struct.unpack(b">HH", data[pos:pos+4])
+			if (tupleIndex & kEmbeddedTupleCoord) != 0:
+				coord = None  # TODO: Implement
+			else:
+				coord = sharedCoords[tupleIndex & kTupleIndexMask].copy()
+			if tracing:
+				print('Tuple %d: pos=%d, tupleSize=%04x, byteSize=%d, index=%04x' % (i, pos, tupleSize, self.getTupleSize(tupleSize), tupleIndex))
+			tupleData = buffer(data, dataPos, tupleSize)
+			tuple = self.decompileTupleData(tuplesSharePointNumbers, coord, tupleData)
+			result.append(tuple)
+			pos += self.getTupleSize(tupleIndex)
+			dataPos += tupleSize
+		print(result)
+		return result
+
+	def OBSOLETE_decompileTupleData(self, tuplesSharePointNumbers, coord, data):
+		#print("    tuplesSharePointNumbers: %s" % tuplesSharePointNumbers)
+		#print("    tupleData: %s" % ' '.join([c.encode('hex') for c in data]))
+		tuple = GlyphVariation(coord)
+		#t.decompilePackedPoints(data)
+		#pos = 0
+		#numPoints = ord(data[pos])
+		#if numPoints >= 0x80:
+		#	pos += 1
+		#	numPoints = (numPoints & 0x7f) << 8 + ord(data[pos])
+		#pos += 1
+		#
+		# 0 means "all points in glyph"; TODO: how to find out this number?
+		#if numPoints != 0:
+		#	# TODO
+		#	pass
+
+		#print("    numPoints: %d" % numPoints)
+		#assert not tuplesSharePointNumbers  # TODO: implement shared point numbers
+		# TODO: decode deltas
+		return tuple
+
+	def getTupleSize(self, tupleIndex):
+		"""Returns the byte size of a tuple given the value of its tupleIndex field."""
+		size = 4
+		if (tupleIndex & EMBEDDED_TUPLE_COORD) != 0:
+			size += self.axisCount * 2
+		if (tupleIndex & INTERMEDIATE_TUPLE) != 0:
+			size += self.axisCount * 4
+		return size
+
+	def toXML(self, writer, ttFont):
+		writer.simpletag("Version", value=self.version)
+		writer.newline()
+		writer.simpletag("Reserved", value=self.reserved)
+		writer.newline()
+
+
+POINTS_ARE_WORDS = 0x80
+POINT_RUN_COUNT_MASK = 0x7F
+
+class GlyphVariation:
+	def __init__(self, axes):
+		self.axes = axes
+		self.coordinates = []
+
+	def __repr__(self):
+		axes = ','.join(sorted(['%s=%s' % (name, value) for (name, value) in self.axes.items()]))
+		return '<GlyphVariation %s>' % axes
+
+	@staticmethod
+	def decompilePoints(data):
+		pos = 0
+		return None
+
+	#def decompilePackedPoints(self, data):
+	#	pos = 0
+	#	numPoints = ord(data[pos])
+	#	if numPoints >= 0x80:
+	#		pos += 1
+	#		numPoints = (numPoints & 0x7f) << 8 | ord(data[pos])
+	#	pos += 1
+	#	points = []
+	#	if numPoints == 0:
+	#		return (points, data[pos:])
+	#	i = 0
+	#	while i < numPoints:
+	#		controlByte = ord(data[pos])
+	#		if (controlByte & 0x80) != 0:
+	#			
+	#			pos += 1
+	#			numPointsInRun = (numPointsInRun & 0x7f) << 8 | ord(data[pos])
+	#		print('********************** numPointsInRun: %d' % numPointsInRun)
+	#		break

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -248,6 +248,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		writer.newline()
 		writer.simpletag("reserved", value=self.reserved)
 		writer.newline()
+		axisTags = [axis.AxisTag for axis in ttFont["fvar"].table.VariationAxis]
 		for glyphName in ttFont.getGlyphOrder():
 			tuples = self.variations.get(glyphName)
 			if not tuples:
@@ -256,10 +257,13 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			writer.newline()
 			for tupleIndex in xrange(len(tuples)):
 				tuple = tuples[tupleIndex]
-				writer.comment("The 'index' attribute is only for humans; it is ignored when parsed.")
+				writer.begintag("tuple")
 				writer.newline()
-				writer.begintag("tuple", index=tupleIndex)
-				writer.newline()
+				for axis in axisTags:
+					value = tuple.axes.get(axis)
+					if value != None and value != 0.0:
+						writer.simpletag("coord", axis=axis, value=value)
+						writer.newline()
 				wrote_any_points = False
 				for i in xrange(len(tuple.coordinates)):
 					x, y = tuple.coordinates[i]

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -55,7 +55,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 						 format=(self.flags & 1), glyphCount=self.glyphCount)
 		sharedCoords = self.decompileSharedCoords_(axisTags, data)
 		self.variations = {}
-		for i in range(self.glyphCount):
+		for i in xrange(self.glyphCount):
 			glyphName = glyphs[i]
 			glyph = ttFont["glyf"][glyphName]
 			if glyph.isComposite():
@@ -70,7 +70,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		result = []
 		pos = self.offsetToCoord
 		stride = len(axisTags) * 2
-		for i in range(self.sharedCoordCount):
+		for i in xrange(self.sharedCoordCount):
 			coord = self.decompileCoord_(axisTags, data[pos:pos+stride])
 			result.append(coord)
 			pos += stride
@@ -118,7 +118,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		into the flags field of the 'gvar' header.
 		"""
 		assert len(offsets) >= 2
-		for i in range(1, len(offsets)):
+		for i in xrange(1, len(offsets)):
 			assert offsets[i - 1] <= offsets[i]
 		if max(offsets) <= 0xffff * 2:
 			packed = array.array(b"H", [n >> 1 for n in offsets])
@@ -139,7 +139,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		tupleCount = tupleCount & TUPLE_COUNT_MASK
 		tuplePos = 4
 		dataPos = offsetToData
-		for i in range(tupleCount):
+		for i in xrange(tupleCount):
 			tupleSize, tupleIndex = struct.unpack(b">HH", data[tuplePos:tuplePos+4])
 			if (tupleIndex & EMBEDDED_TUPLE_COORD) != 0:
 				coord = self.decompileCoord_(axisTags, data[tuplePos+4:])

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -170,11 +170,13 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	def decompileTuple_(numPoints, sharedCoords, sharedPoints, axisTags, data, tupleData):
 		flags = struct.unpack(b">H", data[2:4])[0]
 
+		pos = 4
 		if (flags & EMBEDDED_TUPLE_COORD) == 0:
 			axes = sharedCoords[flags & TUPLE_INDEX_MASK]
 		else:
-			# TODO: Implement this properly.
-			axes = dict([(axis, "TODO") for axis in axisTags])
+			embeddedCoordSize = len(axisTags) * 2
+			axes = table__g_v_a_r.decompileCoord_(axisTags, data[pos:pos+embeddedCoordSize])
+			pos += embeddedCoordSize
 
 		pos = 0
 		if (flags & PRIVATE_POINT_NUMBERS) != 0:

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -258,11 +258,11 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			tuples = self.variations.get(glyphName)
 			if not tuples:
 				continue
-			writer.begintag("glyphVariation", glyph=glyphName)
+			writer.begintag("glyphVariations", glyph=glyphName)
 			writer.newline()
 			for tuple in tuples:
 				tuple.toXML(writer, axisTags)
-			writer.endtag("glyphVariation")
+			writer.endtag("glyphVariations")
 			writer.newline()
 
 
@@ -272,8 +272,8 @@ class GlyphVariation:
 		self.coordinates = coordinates
 
 	def __repr__(self):
-		axes = ",".join(sorted(['%s=%s' % (name, value) for (name, value) in self.axes.items()]))
-		return '<GlyphVariation %s %s>' % (axes, self.coordinates)
+		axes = ",".join(sorted(["%s=%s" % (name, value) for (name, value) in self.axes.items()]))
+		return "<GlyphVariation %s %s>" % (axes, self.coordinates)
 
 	def toXML(self, writer, axisTags):
 		writer.begintag("tuple")

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -4,6 +4,7 @@ from fontTools import ttLib
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
 from fontTools.misc.textTools import safeEval
+from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 from . import DefaultTable
 import array
@@ -528,7 +529,7 @@ class GlyphVariation:
 					pos += 2
 					result.append(point)
 		if max(result) >= numPoints:
-			raise ttLib.TTLibError("malformed 'gvar' table")
+			raise TTLibError("malformed 'gvar' table")
 		return (result, pos)
 
 	@staticmethod

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -122,7 +122,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			glyph = ttFont["glyf"][glyphName]
 			numPoints = self.getNumPoints_(glyph)
 			gvarData = data[self.offsetToData + offsets[i] : self.offsetToData + offsets[i + 1]]
-			self.variations[glyphName] = self.decompileTuples_(numPoints, sharedCoords, axisTags, gvarData)
+			self.variations[glyphName] = self.decompileGlyph_(numPoints, sharedCoords, axisTags, gvarData)
 
 	def decompileSharedCoords_(self, axisTags, data):
 		result, pos = GlyphVariation.decompileCoords_(axisTags, self.sharedCoordCount, data, self.offsetToCoord)
@@ -174,7 +174,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			packed.byteswap()
 		return (packed.tostring(), format)
 
-	def decompileTuples_(self, numPoints, sharedCoords, axisTags, data):
+	def decompileGlyph_(self, numPoints, sharedCoords, axisTags, data):
 		if len(data) < 4:
 			return []
 		tuples = []

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -169,6 +169,13 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	@staticmethod
 	def decompileTuple_(numPoints, sharedCoords, sharedPoints, axisTags, data, tupleData):
 		flags = struct.unpack(b">H", data[2:4])[0]
+
+		if (flags & EMBEDDED_TUPLE_COORD) == 0:
+			axes = sharedCoords[flags & TUPLE_INDEX_MASK]
+		else:
+			# TODO: Implement this properly.
+			axes = dict([(axis, "TODO") for axis in axisTags])
+
 		pos = 0
 		if (flags & PRIVATE_POINT_NUMBERS) != 0:
 			points, pos = table__g_v_a_r.decompilePoints_(numPoints, tupleData, pos)
@@ -176,11 +183,10 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			points = sharedPoints
 		deltas_x, pos = table__g_v_a_r.decompileDeltas_(len(points), tupleData, pos)
 		deltas_y, pos = table__g_v_a_r.decompileDeltas_(len(points), tupleData, pos)
-		coordinates = GlyphCoordinates.zeros(numPoints)
+		deltas = GlyphCoordinates.zeros(numPoints)
 		for p, x, y in zip(points, deltas_x, deltas_y):
-				coordinates[p] = (x, y)
-		axes = dict([(axis, "TODO") for axis in axisTags])
-		return GlyphVariation(axes, coordinates)
+				deltas[p] = (x, y)
+		return GlyphVariation(axes, deltas)
 
 	@staticmethod
 	def decompilePoints_(numPoints, data, offset):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -41,6 +41,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	dependencies = ["fvar", "glyf"]
 
 	def decompile(self, data, ttFont):
+		data = buffer(data)  # We do a lot of slicing; no need to copy all those sub-buffers.
 		axisTags = [axis.AxisTag for axis in ttFont['fvar'].table.VariationAxis]
 		glyphs = ttFont.getGlyphOrder()
 		sstruct.unpack(GVAR_HEADER_FORMAT, data[0:GVAR_HEADER_SIZE], self)

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -18,7 +18,7 @@ import struct
 # FreeType2 source code for parsing 'gvar':
 # http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/src/truetype/ttgxvar.c
 
-GVAR_HEADER_FORMAT = b"""
+GVAR_HEADER_FORMAT = """
 	> # big endian
 	version:		H
 	reserved:		H
@@ -547,22 +547,22 @@ class GlyphVariation:
 	def decompilePoints_(numPoints, data, offset):
 		"""(numPoints, data, offset) --> ([point1, point2, ...], newOffset)"""
 		pos = offset
-		numPointsInData = ord(data[pos])
+		numPointsInData = byteord(data[pos])
 		pos += 1
 		if (numPointsInData & POINTS_ARE_WORDS) != 0:
-			numPointsInData = (numPointsInData & POINT_RUN_COUNT_MASK) << 8 | ord(data[pos])
+			numPointsInData = (numPointsInData & POINT_RUN_COUNT_MASK) << 8 | byteord(data[pos])
 			pos += 1
 		if numPointsInData == 0:
 			return (range(numPoints), pos)
 		result = []
 		while len(result) < numPointsInData:
-			runHeader = ord(data[pos])
+			runHeader = byteord(data[pos])
 			pos += 1
 			numPointsInRun = (runHeader & POINT_RUN_COUNT_MASK) + 1
 			point = 0
 			if (runHeader & POINTS_ARE_WORDS) == 0:
 				for i in range(numPointsInRun):
-					point += ord(data[pos])
+					point += byteord(data[pos])
 					pos += 1
 					result.append(point)
 			else:
@@ -688,7 +688,7 @@ class GlyphVariation:
 		result = []
 		pos = offset
 		while len(result) < numDeltas:
-			runHeader = ord(data[pos])
+			runHeader = byteord(data[pos])
 			pos += 1
 			numDeltasInRun = (runHeader & DELTA_RUN_COUNT_MASK) + 1
 			if (runHeader & DELTAS_ARE_ZERO) != 0:

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -98,16 +98,11 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		return [c[1] for c in sharedCoords]  # Strip off counts.
 
 	def compileGlyphs_(self, ttFont, axisTags, sharedCoordIndices):
-		result = []
-		for glyph in ttFont.getGlyphOrder():
-			if glyph in self.variations:
-				glyphData = self.compileGlyph_(axisTags, sharedCoordIndices, self.variations[glyph])
-			else:
-				glyphData = b""
-			result.append(glyphData)
+		result = [self.compileGlyph_(g, axisTags, sharedCoordIndices) for g in ttFont.getGlyphOrder()]
 		return result
 
-	def compileGlyph_(self, axisTags, sharedCoordIndices, variations):
+	def compileGlyph_(self, glyph, axisTags, sharedCoordIndices):
+		variations = self.variations.get(glyph, [])
 		if len(variations) == 0:
 			return b""
 		return b"TODO"

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -364,6 +364,9 @@ class GlyphVariation:
 		axes = ",".join(sorted(["%s=%s" % (name, value) for (name, value) in self.axes.items()]))
 		return "<GlyphVariation %s %s>" % (axes, self.coordinates)
 
+	def __eq__(self, other):
+		return self.coordinates == other.coordinates and self.axes == other.axes
+
 	def getUsedPoints(self):
 		result = set()
 		for p in range(len(self.coordinates)):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -260,32 +260,8 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 				continue
 			writer.begintag("glyphVariation", glyph=glyphName)
 			writer.newline()
-			for tupleIndex in xrange(len(tuples)):
-				tuple = tuples[tupleIndex]
-				writer.begintag("tuple")
-				writer.newline()
-				for axis in axisTags:
-					value = tuple.axes.get(axis)
-					if value != None:
-						minValue, value, maxValue = value
-						if minValue == value and maxValue == value:
-							writer.simpletag("coord", axis=axis, value=value)
-						else:
-							writer.simpletag("coord", axis=axis, value=value,
-									 min=minValue, max=maxValue)
-						writer.newline()
-				wrote_any_points = False
-				for i in xrange(len(tuple.coordinates)):
-					x, y = tuple.coordinates[i]
-					if x != 0 or y != 0:
-						writer.simpletag("delta", pt=i, x=x, y=y)
-						writer.newline()
-						wrote_any_points = True
-				if not wrote_any_points:
-					writer.comment("all deltas are (0,0)")
-					writer.newline()
-				writer.endtag("tuple")
-				writer.newline()
+			for tuple in tuples:
+				tuple.toXML(writer, axisTags)
 			writer.endtag("glyphVariation")
 			writer.newline()
 
@@ -298,3 +274,29 @@ class GlyphVariation:
 	def __repr__(self):
 		axes = ",".join(sorted(['%s=%s' % (name, value) for (name, value) in self.axes.items()]))
 		return '<GlyphVariation %s %s>' % (axes, self.coordinates)
+
+	def toXML(self, writer, axisTags):
+		writer.begintag("tuple")
+		writer.newline()
+		for axis in axisTags:
+			value = self.axes.get(axis)
+			if value != None:
+				minValue, value, maxValue = value
+				if minValue == value and maxValue == value:
+					writer.simpletag("coord", axis=axis, value=value)
+				else:
+					writer.simpletag("coord", axis=axis, value=value,
+							 min=minValue, max=maxValue)
+				writer.newline()
+		wrote_any_points = False
+		for i in xrange(len(self.coordinates)):
+			x, y = self.coordinates[i]
+			if x != 0 or y != 0:
+				writer.simpletag("delta", pt=i, x=x, y=y)
+				writer.newline()
+				wrote_any_points = True
+		if not wrote_any_points:
+			writer.comment("all deltas are (0,0)")
+			writer.newline()
+		writer.endtag("tuple")
+		writer.newline()

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -503,7 +503,7 @@ class GlyphVariation(object):
 		if numPoints < 0x80:
 			result = [bytechr(numPoints)]
 		else:
-			result = [bytechr((numPoints >> 8) | 0x80) + bytechr(numPoints & 0x7f)]
+			result = [bytechr((numPoints >> 8) | 0x80) + bytechr(numPoints & 0xff)]
 
 		MAX_RUN_LENGTH = 127
 		pos = 0

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -361,7 +361,7 @@ class GlyphVariation(object):
 	def getUsedPoints(self):
 		result = set()
 		for i, point in enumerate(self.coordinates):
-			if point != None:
+			if point is not None:
 				result.add(i)
 		return result
 
@@ -372,7 +372,7 @@ class GlyphVariation(object):
 		without making any visible difference.
 		"""
 		for c in self.coordinates:
-			if c != None:
+			if c is not None:
 				return True
 		return False
 
@@ -392,7 +392,7 @@ class GlyphVariation(object):
 				writer.newline()
 		wrote_any_points = False
 		for i, point in enumerate(self.coordinates):
-			if point != None:
+			if point is not None:
 				writer.simpletag("delta", pt=i, x=point[0], y=point[1])
 				writer.newline()
 				wrote_any_points = True

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -54,7 +54,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 	def compile(self, ttFont):
 		axisTags = [axis.AxisTag for axis in ttFont["fvar"].table.VariationAxis]
 
-		sharedCoords = self.compileSharedCoords_(ttFont, axisTags)
+		sharedCoords = self.compileSharedCoords_(axisTags)
 		sharedCoordIndices = dict([(coord, i) for i, coord in enumerate(sharedCoords)])
 		sharedCoordSize = sum([len(c) for c in sharedCoords])
 
@@ -83,7 +83,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		result.extend(compiledGlyphs)
 		return bytesjoin(result)
 
-	def compileSharedCoords_(self, ttFont, axisTags):
+	def compileSharedCoords_(self, axisTags):
 		coordCount = {}
 		for glyph, variations in self.variations.items():
 			for gvar in variations:

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import floatToFixed
+from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
@@ -478,10 +478,7 @@ class GlyphVariation(object):
 		coord = {}
 		pos = offset
 		for axis in axisTags:
-			# Work around https://github.com/behdad/fonttools/issues/286
-			# coord[axis] = fixedToFloat(struct.unpack(">h", data[pos:pos+2])[0], 14)
-			fixedValue = struct.unpack(">h", data[pos:pos+2])[0]
-			coord[axis] = float(fixedValue) / (1 << 14)
+			coord[axis] = fixedToFloat(struct.unpack(">h", data[pos:pos+2])[0], 14)
 			pos += 2
 		return coord, pos
 

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -85,7 +85,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 
 	def compileSharedCoords_(self, axisTags):
 		coordCount = {}
-		for glyph, variations in self.variations.items():
+		for variations in self.variations.values():
 			for gvar in variations:
 				coord = gvar.compileCoord(axisTags)
 				coordCount[coord] = coordCount.get(coord, 0) + 1

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.fixedTools import floatToFixed
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
@@ -478,7 +478,10 @@ class GlyphVariation(object):
 		coord = {}
 		pos = offset
 		for axis in axisTags:
-			coord[axis] = fixedToFloat(struct.unpack(">h", data[pos:pos+2])[0], 14)
+			# Work around https://github.com/behdad/fonttools/issues/286
+			# coord[axis] = fixedToFloat(struct.unpack(">h", data[pos:pos+2])[0], 14)
+			fixedValue = struct.unpack(">h", data[pos:pos+2])[0]
+			coord[axis] = float(fixedValue) / (1 << 14)
 			pos += 2
 		return coord, pos
 

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -490,6 +490,11 @@ class GlyphVariation(object):
 
 	@staticmethod
 	def compilePoints(points, numPointsInGlyph):
+		# If the set consists of all points in the glyph, it gets encoded with
+		# a special encoding: a single zero byte.
+		if len(points) == numPointsInGlyph:
+			return b"\0"
+
 		# In the 'gvar' table, the packing of point numbers is a little surprising.
 		# It consists of multiple runs, each being a delta-encoded list of integers.
 		# For example, the point set {17, 18, 19, 20, 21, 22, 23} gets encoded as

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -56,7 +56,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 		axisTags = [axis.AxisTag for axis in ttFont["fvar"].table.VariationAxis]
 
 		sharedCoords = self.compileSharedCoords_(ttFont, axisTags)
-		sharedCoordIndices = dict([(sharedCoords[i], i) for i in range(len(sharedCoords))])
+		sharedCoordIndices = dict([(coord, i) for i, coord in enumerate(sharedCoords)])
 		sharedCoordSize = sum([len(c) for c in sharedCoords])
 
 		compiledGlyphs = self.compileGlyphs_(ttFont, axisTags, sharedCoordIndices)
@@ -365,9 +365,9 @@ class GlyphVariation(object):
 
 	def getUsedPoints(self):
 		result = set()
-		for p in range(len(self.coordinates)):
-			if self.coordinates[p] != (0, 0):
-				result.add(p)
+		for i, point in enumerate(self.coordinates):
+			if point != (0, 0):
+				result.add(i)
 		return result
 
 	def hasImpact(self):
@@ -396,8 +396,7 @@ class GlyphVariation(object):
 					writer.simpletag("coord", axis=axis, value=value, min=minValue, max=maxValue)
 				writer.newline()
 		wrote_any_points = False
-		for i in range(len(self.coordinates)):
-			x, y = self.coordinates[i]
+		for i, (x, y) in enumerate(self.coordinates):
 			if x != 0 or y != 0:
 				writer.simpletag("delta", pt=i, x=x, y=y)
 				writer.newline()

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -86,11 +86,10 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 
 	def compileSharedCoords_(self, ttFont, axisTags):
 		coordCount = {}
-		for glyph in ttFont.getGlyphOrder():
-			if glyph in self.variations:
-				for gvar in self.variations[glyph]:
-					coord = gvar.compileCoord(axisTags)
-					coordCount[coord] = coordCount.get(coord, 0) + 1
+		for glyph, variations in self.variations.items():
+			for gvar in variations:
+				coord = gvar.compileCoord(axisTags)
+				coordCount[coord] = coordCount.get(coord, 0) + 1
 		sharedCoords = [(count, coord) for (coord, count) in coordCount.items() if count > 1]
 		sharedCoords.sort(reverse=True)
 		MAX_NUM_SHARED_COORDS = TUPLE_INDEX_MASK + 1

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -233,6 +233,20 @@ class GlyphVariationTest(unittest.TestCase):
 		data = hexdecode("DE AD 40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00")
 		self.assertEqual((coords, 20), decompileCoords(axes, numCoords=3, data=data, offset=2))
 
+	def test_compilePoints(self):
+		compilePoints = GlyphVariation.compilePoints
+		self.assertEquals("01 00 07", hexencode(compilePoints({7})))
+		self.assertEquals("01 80 FF FF", hexencode(compilePoints({65535})))
+		self.assertEquals("02 01 09 06", hexencode(compilePoints({9, 15})))
+		self.assertEquals("06 05 07 01 F7 02 01 F2", hexencode(compilePoints({7, 8, 255, 257, 258, 500})))
+		self.assertEquals("03 01 07 01 80 01 F4", hexencode(compilePoints({7, 8, 500})))
+		self.assertEquals("04 01 07 01 81 BE EF 0C 0F", hexencode(compilePoints({7, 8, 0xBEEF, 0xCAFE})))
+		self.assertEquals("81 2C" +  # 300 points (0x12c) in total
+				  " 7F 00" + (127 * " 01") +  # first run, contains 128 points: [0 .. 127]
+				  " 7F 80" + (127 * " 01") +  # second run, contains 128 points: [128 .. 511]
+				  " AB 01 00" + (43 * " 00 01"),  # third run, contains 44 points: [512 .. 299]
+				  hexencode(compilePoints(set(xrange(300)))))
+
 	def test_decompilePoints(self):
 		decompilePoints = GlyphVariation.decompilePoints_
 		numPoints = 65536

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 from fontTools.misc.py23 import *
+from fontTools.misc.textTools import deHexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
@@ -7,16 +8,13 @@ from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r, GlyphVariation
 import random
 import unittest
 
-def hexdecode(s):
-	return bytesjoin([c.decode("hex") for c in s.split()])
-
 def hexencode(s):
 	return ' '.join([c.encode("hex").upper() for c in s])
 
 # Glyph variation table of uppercase I in the Skia font, as printed in Apple's
 # TrueType spec. The actual Skia font uses a different table for uppercase I.
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gvar.html
-SKIA_GVAR_I = hexdecode(
+SKIA_GVAR_I = deHexStr(
 	"00 08 00 24 00 33 20 00 00 15 20 01 00 1B 20 02 "
 	"00 24 20 03 00 15 20 04 00 26 20 07 00 0D 20 06 "
 	"00 1A 20 05 00 40 01 01 01 81 80 43 FF 7E FF 7E "
@@ -36,29 +34,29 @@ SKIA_GVAR_I = hexdecode(
 	"FF FF FF 81 00 08 81 82 02 EE EE EE 8B 6D 00")
 
 # Shared coordinates in the Skia font, as printed in Apple's TrueType spec.
-SKIA_SHARED_COORDS = hexdecode(
+SKIA_SHARED_COORDS = deHexStr(
 	"40 00 00 00 C0 00 00 00 00 00 40 00 00 00 C0 00 "
 	"C0 00 C0 00 40 00 C0 00 40 00 40 00 C0 00 40 00")
 
 
 class GlyphVariationTableTest(unittest.TestCase):
 	def test_compileOffsets_shortFormat(self):
-		self.assertEqual((hexdecode("00 00 00 02 FF C0"), 0),
+		self.assertEqual((deHexStr("00 00 00 02 FF C0"), 0),
 				 table__g_v_a_r.compileOffsets_([0, 4, 0x1ff80]))
 
 	def test_compileOffsets_longFormat(self):
-		self.assertEqual((hexdecode("00 00 00 00 00 00 00 04 CA FE BE EF"), 1),
+		self.assertEqual((deHexStr("00 00 00 00 00 00 00 04 CA FE BE EF"), 1),
 				 table__g_v_a_r.compileOffsets_([0, 4, 0xCAFEBEEF]))
 
 	def test_decompileOffsets_shortFormat(self):
 		decompileOffsets = table__g_v_a_r.decompileOffsets_
-		data = hexdecode("00 11 22 33 44 55 66 77 88 99 aa bb")
+		data = deHexStr("00 11 22 33 44 55 66 77 88 99 aa bb")
 		self.assertEqual([2*0x0011, 2*0x2233, 2*0x4455, 2*0x6677, 2*0x8899, 2*0xaabb],
 				 list(decompileOffsets(data, format=0, glyphCount=5)))
 
 	def test_decompileOffsets_longFormat(self):
 		decompileOffsets = table__g_v_a_r.decompileOffsets_
-		data = hexdecode("00 11 22 33 44 55 66 77 88 99 aa bb")
+		data = deHexStr("00 11 22 33 44 55 66 77 88 99 aa bb")
 		self.assertEqual([0x00112233, 0x44556677, 0x8899aabb],
 				 list(decompileOffsets(data, format=1, glyphCount=2)))
 
@@ -335,7 +333,7 @@ class GlyphVariationTest(unittest.TestCase):
 
 	def test_decompileCoord(self):
 		decompileCoord = GlyphVariation.decompileCoord_
-		data = hexdecode("DE AD C0 00 20 00 DE AD")
+		data = deHexStr("DE AD C0 00 20 00 DE AD")
 		self.assertEqual(({"wght": -1.0, "wdth": 0.5}, 6), decompileCoord(["wght", "wdth"], data, 2))
 
 	def test_decompileCoords(self):
@@ -346,7 +344,7 @@ class GlyphVariationTest(unittest.TestCase):
 			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
 			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
 		]
-		data = hexdecode("DE AD 40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00")
+		data = deHexStr("DE AD 40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00")
 		self.assertEqual((coords, 20), decompileCoords(axes, numCoords=3, data=data, offset=2))
 
 	def test_compilePoints(self):
@@ -368,30 +366,30 @@ class GlyphVariationTest(unittest.TestCase):
 		numPoints = 65536
 		allPoints = range(numPoints)
 		# all points in glyph
-		self.assertEqual((allPoints, 1), decompilePoints(numPoints, hexdecode("00"), 0))
+		self.assertEqual((allPoints, 1), decompilePoints(numPoints, deHexStr("00"), 0))
 		# all points in glyph (in overly verbose encoding, not explicitly prohibited by spec)
-		self.assertEqual((allPoints, 2), decompilePoints(numPoints, hexdecode("80 00"), 0))
+		self.assertEqual((allPoints, 2), decompilePoints(numPoints, deHexStr("80 00"), 0))
 		# 2 points; first run: [9, 9+6]
-		self.assertEqual(([9, 15], 4), decompilePoints(numPoints, hexdecode("02 01 09 06"), 0))
+		self.assertEqual(([9, 15], 4), decompilePoints(numPoints, deHexStr("02 01 09 06"), 0))
 		# 2 points; first run: [0xBEEF, 0xCAFE]. (0x0C0F = 0xCAFE - 0xBEEF)
-		self.assertEqual(([0xBEEF, 0xCAFE], 6), decompilePoints(numPoints, hexdecode("02 81 BE EF 0C 0F"), 0))
+		self.assertEqual(([0xBEEF, 0xCAFE], 6), decompilePoints(numPoints, deHexStr("02 81 BE EF 0C 0F"), 0))
 		# 1 point; first run: [7]
-		self.assertEqual(([7], 3), decompilePoints(numPoints, hexdecode("01 00 07"), 0))
+		self.assertEqual(([7], 3), decompilePoints(numPoints, deHexStr("01 00 07"), 0))
 		# 1 point; first run: [7] in overly verbose encoding
-		self.assertEqual(([7], 4), decompilePoints(numPoints, hexdecode("01 80 00 07"), 0))
+		self.assertEqual(([7], 4), decompilePoints(numPoints, deHexStr("01 80 00 07"), 0))
 		# 1 point; first run: [65535]; requires words to be treated as unsigned numbers
-		self.assertEqual(([65535], 4), decompilePoints(numPoints, hexdecode("01 80 FF FF"), 0))
+		self.assertEqual(([65535], 4), decompilePoints(numPoints, deHexStr("01 80 FF FF"), 0))
 		# 4 points; first run: [7, 8]; second run: [255, 257]. 257 is stored in delta-encoded bytes (0xFF + 2).
-		self.assertEqual(([7, 8, 255, 257], 7), decompilePoints(numPoints, hexdecode("04 01 07 01 01 FF 02"), 0))
+		self.assertEqual(([7, 8, 255, 257], 7), decompilePoints(numPoints, deHexStr("04 01 07 01 01 FF 02"), 0))
 		# combination of all encodings, preceded and followed by 4 bytes of unused data
-		data = hexdecode("DE AD DE AD 04 01 07 01 81 BE EF 0C 0F DE AD DE AD")
+		data = deHexStr("DE AD DE AD 04 01 07 01 81 BE EF 0C 0F DE AD DE AD")
 		self.assertEqual(([7, 8, 0xBEEF, 0xCAFE], 13), decompilePoints(numPoints, data, 4))
 
 	def test_decompilePoints_shouldGuardAgainstBadPointNumbers(self):
 		decompilePoints = GlyphVariation.decompilePoints_
 		# 2 points; first run: [3, 9].
 		numPoints = 8
-		self.assertRaises(TTLibError, decompilePoints, numPoints, hexdecode("02 01 03 06"), 0)
+		self.assertRaises(TTLibError, decompilePoints, numPoints, deHexStr("02 01 03 06"), 0)
 
 	def test_decompilePoints_roundTrip(self):
 		numPointsInGlyph = 500  # greater than 255, so we also exercise code path for 16-bit encoding
@@ -452,13 +450,13 @@ class GlyphVariationTest(unittest.TestCase):
 	def test_decompileDeltas(self):
 		decompileDeltas = GlyphVariation.decompileDeltas_
 		# 83 = zero values (0x80), count = 4 (1 + 0x83 & 0x3F)
-		self.assertEqual(([0, 0, 0, 0], 1), decompileDeltas(4, hexdecode("83"), 0))
+		self.assertEqual(([0, 0, 0, 0], 1), decompileDeltas(4, deHexStr("83"), 0))
 		# 41 01 02 FF FF = signed 16-bit values (0x40), count = 2 (1 + 0x41 & 0x3F)
-		self.assertEqual(([258, -1], 5), decompileDeltas(2, hexdecode("41 01 02 FF FF"), 0))
+		self.assertEqual(([258, -1], 5), decompileDeltas(2, deHexStr("41 01 02 FF FF"), 0))
 		# 01 81 07 = signed 8-bit values, count = 2 (1 + 0x01 & 0x3F)
-		self.assertEqual(([-127, 7], 3), decompileDeltas(2, hexdecode("01 81 07"), 0))
+		self.assertEqual(([-127, 7], 3), decompileDeltas(2, deHexStr("01 81 07"), 0))
 		# combination of all three encodings, preceded and followed by 4 bytes of unused data
-		data = hexdecode("DE AD BE EF 83 40 01 02 01 81 80 DE AD BE EF")
+		data = deHexStr("DE AD BE EF 83 40 01 02 01 81 80 DE AD BE EF")
 		self.assertEqual(([0, 0, 0, 0, 258, -127, -128], 11), decompileDeltas(7, data, 4))
 
 	def test_decompileDeltas_roundTrip(self):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -61,6 +61,16 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual([0x00112233, 0x44556677, 0x8899aabb],
 				 list(decompileOffsets(data, format=1, glyphCount=2)))
 
+	def test_compileGlyph_noVariations(self):
+		table = table__g_v_a_r()
+		table.variations = {}
+		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+
+	def test_compileGlyph_emptyVariations(self):
+		table = table__g_v_a_r()
+		table.variations = {"glyphname": []}
+		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+
 	def test_compileSharedCoords(self):
 		class FakeFont:
 			def getGlyphOrder(self):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -279,7 +279,7 @@ class GlyphVariationTest(unittest.TestCase):
 		self.assertRaises(TTLibError, decompilePoints, numPoints, hexdecode("02 01 03 06"), 0)
 
 	def test_decompilePoints_roundTrip(self):
-		numPointsInGlyph = 500  # greater than 255, so we also test 16-bit encoding
+		numPointsInGlyph = 500  # greater than 255, so we also exercise code path for 16-bit encoding
 		compile = GlyphVariation.compilePoints
 		decompile = lambda data: set(GlyphVariation.decompilePoints_(numPointsInGlyph, data, 0)[0])
 		for i in xrange(50):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -57,6 +57,11 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual((hexdecode("00 00 00 00 00 00 00 04 CA FE BE EF"), 1),
 				 table__g_v_a_r.compileOffsets_([0, 4, 0xCAFEBEEF]))
 
+	def test_decompileCoord(self):
+		decompileCoord = table__g_v_a_r.decompileCoord_
+		data = hexdecode("DE AD C0 00 20 00 DE AD")
+		self.assertEqual(({"wght": -1.0, "wdth": 0.5}, 6), decompileCoord(["wght", "wdth"], data, 2))
+
 	def test_decompileSharedCoords(self):
 		table = table__g_v_a_r()
 		table.offsetToCoord = 4

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -61,37 +61,6 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual((hexdecode("00 00 00 00 00 00 00 04 CA FE BE EF"), 1),
 				 table__g_v_a_r.compileOffsets_([0, 4, 0xCAFEBEEF]))
 
-	def test_decompileCoord(self):
-		decompileCoord = table__g_v_a_r.decompileCoord_
-		data = hexdecode("DE AD C0 00 20 00 DE AD")
-		self.assertEqual(({"wght": -1.0, "wdth": 0.5}, 6), decompileCoord(["wght", "wdth"], data, 2))
-
-	def test_compileCoord(self):
-		compileCoord = table__g_v_a_r.compileCoord_
-		self.assertEqual("C0 00 20 00", hexencode(compileCoord(["wght", "wdth"], {"wght": -1.0, "wdth": 0.5})))
-
-	def test_decompileCoords(self):
-		decompileCoords = table__g_v_a_r.decompileCoords_
-		axes = ["wght", "wdth", "opsz"]
-		coords = [
-			{"wght":  1.0, "wdth": 0.0, "opsz": 0.5},
-			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
-			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
-		]
-		data = hexdecode("DE AD 40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00")
-		self.assertEqual((coords, 20), decompileCoords(axes, numCoords=3, data=data, offset=2))
-
-	def test_compileCoords(self):
-		compileCoords = table__g_v_a_r.compileCoords_
-		axes = ["wght", "wdth", "opsz"]
-		coords = [
-			{"wght":  1.0, "wdth": 0.0, "opsz": 0.5},
-			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
-			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
-		]
-		self.assertEqual("40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00",
-				 hexencode(compileCoords(axes, coords)))
-
 	def test_decompileSharedCoords_Skia(self):
 		table = table__g_v_a_r()
 		table.offsetToCoord = 0
@@ -131,14 +100,6 @@ class GlyphVariationTableTest(unittest.TestCase):
 	def test_decompileTuples_empty(self):
 		table = table__g_v_a_r()
 		self.assertEqual([], table.decompileTuples_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
-
-	def test_getTupleSize(self):
-		getTupleSize = table__g_v_a_r.getTupleSize_
-		axisCount = 3
-		self.assertEqual(4 + axisCount * 2, getTupleSize(0x8042, axisCount))
-		self.assertEqual(4 + axisCount * 4, getTupleSize(0x4077, axisCount))
-		self.assertEqual(4, getTupleSize(0x2077, axisCount))
-		self.assertEqual(4, getTupleSize(11, axisCount))
 
 	def test_decompilePoints(self):
 		decompilePoints = table__g_v_a_r.decompilePoints_
@@ -211,6 +172,44 @@ class GlyphVariationTest(unittest.TestCase):
 			  '<!-- all deltas are (0,0) -->',
 			'</tuple>'
 		], GlyphVariationTest.xml_lines(writer))
+
+	def test_decompileCoord(self):
+		decompileCoord = GlyphVariation.decompileCoord_
+		data = hexdecode("DE AD C0 00 20 00 DE AD")
+		self.assertEqual(({"wght": -1.0, "wdth": 0.5}, 6), decompileCoord(["wght", "wdth"], data, 2))
+
+	def test_compileCoord(self):
+		compileCoord = GlyphVariation.compileCoord_
+		self.assertEqual("C0 00 20 00", hexencode(compileCoord(["wght", "wdth"], {"wght": -1.0, "wdth": 0.5})))
+
+	def test_decompileCoords(self):
+		decompileCoords = GlyphVariation.decompileCoords_
+		axes = ["wght", "wdth", "opsz"]
+		coords = [
+			{"wght":  1.0, "wdth": 0.0, "opsz": 0.5},
+			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
+			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
+		]
+		data = hexdecode("DE AD 40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00")
+		self.assertEqual((coords, 20), decompileCoords(axes, numCoords=3, data=data, offset=2))
+
+	def test_compileCoords(self):
+		axes = ["wght", "wdth", "opsz"]
+		coords = [
+			{"wght":  1.0, "wdth": 0.0, "opsz": 0.5},
+			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
+			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
+		]
+		self.assertEqual("40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00",
+				 hexencode(GlyphVariation.compileCoords_(axes, coords)))
+
+	def test_getTupleSize(self):
+		getTupleSize = GlyphVariation.getTupleSize_
+		numAxes = 3
+		self.assertEqual(4 + numAxes * 2, getTupleSize(0x8042, numAxes))
+		self.assertEqual(4 + numAxes * 4, getTupleSize(0x4077, numAxes))
+		self.assertEqual(4, getTupleSize(0x2077, numAxes))
+		self.assertEqual(4, getTupleSize(11, numAxes))
 
 	@staticmethod
 	def xml_lines(writer):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -65,12 +65,12 @@ class GlyphVariationTableTest(unittest.TestCase):
 	def test_compileGlyph_noVariations(self):
 		table = table__g_v_a_r()
 		table.variations = {}
-		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+		self.assertEqual(b"", table.compileGlyph_("glyphname", 8, ["wght", "opsz"], {}))
 
 	def test_compileGlyph_emptyVariations(self):
 		table = table__g_v_a_r()
 		table.variations = {"glyphname": []}
-		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+		self.assertEqual(b"", table.compileGlyph_("glyphname", 8, ["wght", "opsz"], {}))
 
 	def test_compileGlyph_onlyRedundantVariations(self):
 		table = table__g_v_a_r()
@@ -80,7 +80,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 			GlyphVariation(axes, GlyphCoordinates.zeros(4)),
 			GlyphVariation(axes, GlyphCoordinates.zeros(4))
 		]}
-		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+		self.assertEqual(b"", table.compileGlyph_("glyphname", 8, ["wght", "opsz"], {}))
 
 	def test_compileSharedCoords(self):
 		class FakeFont:

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 from fontTools.misc.py23 import *
-from fontTools.misc.textTools import deHexStr
+from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
@@ -9,7 +9,8 @@ import random
 import unittest
 
 def hexencode(s):
-	return ' '.join([c.encode("hex").upper() for c in s])
+	h = hexStr(s).upper()
+	return ' '.join([h[i:i+2] for i in range(0, len(h), 2)])
 
 # Glyph variation table of uppercase I in the Skia font, as printed in Apple's
 # TrueType spec. The actual Skia font uses a different table for uppercase I.

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -53,13 +53,13 @@ class GlyphVariationTableTest(unittest.TestCase):
 		decompileOffsets = table__g_v_a_r.decompileOffsets_
 		data = deHexStr("00 11 22 33 44 55 66 77 88 99 aa bb")
 		self.assertEqual([2*0x0011, 2*0x2233, 2*0x4455, 2*0x6677, 2*0x8899, 2*0xaabb],
-				 list(decompileOffsets(data, format=0, glyphCount=5)))
+				 list(decompileOffsets(data, tableFormat=0, glyphCount=5)))
 
 	def test_decompileOffsets_longFormat(self):
 		decompileOffsets = table__g_v_a_r.decompileOffsets_
 		data = deHexStr("00 11 22 33 44 55 66 77 88 99 aa bb")
 		self.assertEqual([0x00112233, 0x44556677, 0x8899aabb],
-				 list(decompileOffsets(data, format=1, glyphCount=2)))
+				 list(decompileOffsets(data, tableFormat=1, glyphCount=2)))
 
 	def test_compileGlyph_noVariations(self):
 		table = table__g_v_a_r()

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -71,6 +71,16 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table.variations = {"glyphname": []}
 		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
 
+	def test_compileGlyph_onlyRedundantVariations(self):
+		table = table__g_v_a_r()
+		axes = {"wght": (0.3, 0.4, 0.5), "opsz": (0.7, 0.8, 0.9)}
+		table.variations = {"glyphname": [
+			GlyphVariation(axes, GlyphCoordinates.zeros(4)),
+			GlyphVariation(axes, GlyphCoordinates.zeros(4)),
+			GlyphVariation(axes, GlyphCoordinates.zeros(4))
+		]}
+		self.assertEqual(b"", table.compileGlyph_("glyphname", ["wght", "opsz"], {}))
+
 	def test_compileSharedCoords(self):
 		class FakeFont:
 			def getGlyphOrder(self):
@@ -142,6 +152,16 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual({"wght": 0.0, "wdth": 0.7}, maxCoord)
 
 class GlyphVariationTest(unittest.TestCase):
+	def test_hasImpact_someDeltasNotZero(self):
+		axes = {"wght":(0.0, 1.0, 1.0)}
+		gvar = GlyphVariation(axes, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		self.assertTrue(gvar.hasImpact())
+
+	def test_hasImpact_allDeltasZero(self):
+		axes = {"wght":(0.0, 1.0, 1.0)}
+		gvar = GlyphVariation(axes, GlyphCoordinates([(0,0), (0,0), (0,0)]))
+		self.assertFalse(gvar.hasImpact())
+
 	def test_toXML(self):
 		writer = XMLWriter(StringIO())
 		axes = {"wdth":(0.3, 0.4, 0.5), "wght":(0.0, 1.0, 1.0), "opsz":(-0.7, -0.7, 0.0)}

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -102,6 +102,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
 		tuples = table.decompileTuples_(18, sharedCoords, axes, SKIA_GVAR_I)
 		self.assertEqual(8, len(tuples))
+		self.assertEqual({"wdth": 0.0, "wght": 1.0}, tuples[0].axes)
 		self.assertEqual("257,0 -127,0 -128,58 -130,90 -130,62 -130,67 -130,32 -127,0 257,0 "
 				 "259,14 260,64 260,21 260,69 258,124 0,0 130,0 0,0 0,0",
 				 " ".join(["%d,%d" % c for c in tuples[0].coordinates]))

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -102,7 +102,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
 		tuples = table.decompileTuples_(18, sharedCoords, axes, SKIA_GVAR_I)
 		self.assertEqual(8, len(tuples))
-		self.assertEqual({"wdth": 0.0, "wght": 1.0}, tuples[0].axes)
+		self.assertEqual({"wght": (1.0, 1.0, 1.0)}, tuples[0].axes)
 		self.assertEqual("257,0 -127,0 -128,58 -130,90 -130,62 -130,67 -130,32 -127,0 257,0 "
 				 "259,14 260,64 260,21 260,69 258,124 0,0 130,0 0,0 0,0",
 				 " ".join(["%d,%d" % c for c in tuples[0].coordinates]))

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -90,7 +90,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		gvar2 = GlyphVariation({"wght": (1.0, 1.0, 1.0), "wdth": (1.0, 1.0, 1.0)}, glyphCoords)
 		table.variations = {"oslash": [gvar1, gvar2]}
 		data = table.compileGlyph_("oslash", numPoints, axisTags, {})
-		print(table.decompileGlyph_(numPoints, {}, axisTags, data))
+		self.assertEqual([gvar1, gvar2], table.decompileGlyph_(numPoints, {}, axisTags, data))
 
 	def test_compileSharedCoords(self):
 		class FakeFont:
@@ -163,6 +163,21 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual({"wght": 0.0, "wdth": 0.7}, maxCoord)
 
 class GlyphVariationTest(unittest.TestCase):
+	def test_equal(self):
+		gvar1 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		gvar2 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		self.assertEqual(gvar1, gvar2)
+
+	def test_equal_differentAxes(self):
+		gvar1 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		gvar2 = GlyphVariation({"wght":(0.7, 0.8, 0.9)}, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		self.assertNotEqual(gvar1, gvar2)
+
+	def test_equal_differentCoordinates(self):
+		gvar1 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, GlyphCoordinates([(0,0), (9,8), (7,6)]))
+		gvar2 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, GlyphCoordinates([(0,0), (9,8)]))
+		self.assertNotEqual(gvar1, gvar2)
+
 	def test_hasImpact_someDeltasNotZero(self):
 		axes = {"wght":(0.0, 1.0, 1.0)}
 		gvar = GlyphVariation(axes, GlyphCoordinates([(0,0), (9,8), (7,6)]))

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -117,23 +117,23 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table.sharedCoordCount = 0
 		self.assertEqual([], table.decompileSharedCoords_(["wght"], b""))
 
-	def test_decompileTuples_Skia_I(self):
+	def test_decompilGlyph_Skia_I(self):
 		axes = ["wght", "wdth"]
 		table = table__g_v_a_r()
 		table.offsetToCoord = 0
 		table.sharedCoordCount = 8
 		table.axisCount = len(axes)
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
-		tuples = table.decompileTuples_(18, sharedCoords, axes, SKIA_GVAR_I)
+		tuples = table.decompileGlyph_(18, sharedCoords, axes, SKIA_GVAR_I)
 		self.assertEqual(8, len(tuples))
 		self.assertEqual({"wght": (0.0, 1.0, 1.0)}, tuples[0].axes)
 		self.assertEqual("257,0 -127,0 -128,58 -130,90 -130,62 -130,67 -130,32 -127,0 257,0 "
 				 "259,14 260,64 260,21 260,69 258,124 0,0 130,0 0,0 0,0",
 				 " ".join(["%d,%d" % c for c in tuples[0].coordinates]))
 
-	def test_decompileTuples_empty(self):
+	def test_decompileGlyph_empty(self):
 		table = table__g_v_a_r()
-		self.assertEqual([], table.decompileTuples_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
+		self.assertEqual([], table.decompileGlyph_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
 
 	def test_computeMinMaxCord(self):
 		coord = {"wght": -0.3, "wdth": 0.7}

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -117,7 +117,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table.sharedCoordCount = 0
 		self.assertEqual([], table.decompileSharedCoords_(["wght"], b""))
 
-	def test_decompilGlyph_Skia_I(self):
+	def test_decompileGlyph_Skia_I(self):
 		axes = ["wght", "wdth"]
 		table = table__g_v_a_r()
 		table.offsetToCoord = 0

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -100,8 +100,11 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table.sharedCoordCount = 8
 		table.axisCount = len(axes)
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
-		tuples = table.decompileTuples_(99, sharedCoords, axes, SKIA_GVAR_I)
+		tuples = table.decompileTuples_(18, sharedCoords, axes, SKIA_GVAR_I)
 		self.assertEqual(8, len(tuples))
+		self.assertEqual("257,0 -127,0 -128,58 -130,90 -130,62 -130,67 -130,32 -127,0 257,0 "
+				 "259,14 260,64 260,21 260,69 258,124 0,0 130,0 0,0 0,0",
+				 " ".join(["%d,%d" % c for c in tuples[0].coordinates]))
 
 	def test_decompileTuples_empty(self):
 		table = table__g_v_a_r()
@@ -118,30 +121,30 @@ class GlyphVariationTableTest(unittest.TestCase):
 	def test_decompilePoints(self):
 		decompilePoints = table__g_v_a_r.decompilePoints_
 		numPoints = 65536
-		allPoints = set(xrange(numPoints))
+		allPoints = range(numPoints)
 		# all points in glyph
 		self.assertEqual((allPoints, 1), decompilePoints(numPoints, hexdecode("00"), 0))
 		# all points in glyph (in overly verbose encoding, not explicitly prohibited by spec)
 		self.assertEqual((allPoints, 2), decompilePoints(numPoints, hexdecode("80 00"), 0))
-		# 2 points; first run: {9, 9+6}
-		self.assertEqual(({9, 15}, 4), decompilePoints(numPoints, hexdecode("02 01 09 06"), 0))
-		# 2 points; first run: {0xBEEF, 0xCAFE}. (0x0C0F = 0xCAFE - 0xBEEF)
-		self.assertEqual(({0xBEEF, 0xCAFE}, 6), decompilePoints(numPoints, hexdecode("02 81 BE EF 0C 0F"), 0))
-		# 1 point; first run: {7}
-		self.assertEqual(({7}, 3), decompilePoints(numPoints, hexdecode("01 00 07"), 0))
-		# 1 point; first run: {7} in overly verbose encoding
-		self.assertEqual(({7}, 4), decompilePoints(numPoints, hexdecode("01 80 00 07"), 0))
-		# 1 point; first run: {65535}; requires words to be treated as unsigned numbers
-		self.assertEqual(({65535}, 4), decompilePoints(numPoints, hexdecode("01 80 FF FF"), 0))
-		# 4 points; first run: {7, 8}; second run: {255, 257}. 257 is stored in delta-encoded bytes (0xFF + 2).
-		self.assertEqual(({7, 8, 255, 257}, 7), decompilePoints(numPoints, hexdecode("04 01 07 01 01 FF 02"), 0))
+		# 2 points; first run: [9, 9+6]
+		self.assertEqual(([9, 15], 4), decompilePoints(numPoints, hexdecode("02 01 09 06"), 0))
+		# 2 points; first run: [0xBEEF, 0xCAFE]. (0x0C0F = 0xCAFE - 0xBEEF)
+		self.assertEqual(([0xBEEF, 0xCAFE], 6), decompilePoints(numPoints, hexdecode("02 81 BE EF 0C 0F"), 0))
+		# 1 point; first run: [7]
+		self.assertEqual(([7], 3), decompilePoints(numPoints, hexdecode("01 00 07"), 0))
+		# 1 point; first run: [7] in overly verbose encoding
+		self.assertEqual(([7], 4), decompilePoints(numPoints, hexdecode("01 80 00 07"), 0))
+		# 1 point; first run: [65535]; requires words to be treated as unsigned numbers
+		self.assertEqual(([65535], 4), decompilePoints(numPoints, hexdecode("01 80 FF FF"), 0))
+		# 4 points; first run: [7, 8]; second run: [255, 257]. 257 is stored in delta-encoded bytes (0xFF + 2).
+		self.assertEqual(([7, 8, 255, 257], 7), decompilePoints(numPoints, hexdecode("04 01 07 01 01 FF 02"), 0))
 		# combination of all encodings, preceded and followed by 4 bytes of unused data
 		data = hexdecode("DE AD DE AD 04 01 07 01 81 BE EF 0C 0F DE AD DE AD")
-		self.assertEqual(({7, 8, 0xBEEF, 0xCAFE}, 13), decompilePoints(numPoints, data, 4))
+		self.assertEqual(([7, 8, 0xBEEF, 0xCAFE], 13), decompilePoints(numPoints, data, 4))
 
 	def test_decompilePoints_shouldGuardAgainstBadPointNumbers(self):
 		decompilePoints = table__g_v_a_r.decompilePoints_
-		# 2 points; first run: {3, 9}.
+		# 2 points; first run: [3, 9].
 		numPoints = 8
 		self.assertRaises(ttLib.TTLibError, decompilePoints, numPoints, hexdecode("02 01 03 06"), 0)
 

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -101,48 +101,6 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table = table__g_v_a_r()
 		self.assertEqual([], table.decompileTuples_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
 
-	def test_decompilePoints(self):
-		decompilePoints = table__g_v_a_r.decompilePoints_
-		numPoints = 65536
-		allPoints = range(numPoints)
-		# all points in glyph
-		self.assertEqual((allPoints, 1), decompilePoints(numPoints, hexdecode("00"), 0))
-		# all points in glyph (in overly verbose encoding, not explicitly prohibited by spec)
-		self.assertEqual((allPoints, 2), decompilePoints(numPoints, hexdecode("80 00"), 0))
-		# 2 points; first run: [9, 9+6]
-		self.assertEqual(([9, 15], 4), decompilePoints(numPoints, hexdecode("02 01 09 06"), 0))
-		# 2 points; first run: [0xBEEF, 0xCAFE]. (0x0C0F = 0xCAFE - 0xBEEF)
-		self.assertEqual(([0xBEEF, 0xCAFE], 6), decompilePoints(numPoints, hexdecode("02 81 BE EF 0C 0F"), 0))
-		# 1 point; first run: [7]
-		self.assertEqual(([7], 3), decompilePoints(numPoints, hexdecode("01 00 07"), 0))
-		# 1 point; first run: [7] in overly verbose encoding
-		self.assertEqual(([7], 4), decompilePoints(numPoints, hexdecode("01 80 00 07"), 0))
-		# 1 point; first run: [65535]; requires words to be treated as unsigned numbers
-		self.assertEqual(([65535], 4), decompilePoints(numPoints, hexdecode("01 80 FF FF"), 0))
-		# 4 points; first run: [7, 8]; second run: [255, 257]. 257 is stored in delta-encoded bytes (0xFF + 2).
-		self.assertEqual(([7, 8, 255, 257], 7), decompilePoints(numPoints, hexdecode("04 01 07 01 01 FF 02"), 0))
-		# combination of all encodings, preceded and followed by 4 bytes of unused data
-		data = hexdecode("DE AD DE AD 04 01 07 01 81 BE EF 0C 0F DE AD DE AD")
-		self.assertEqual(([7, 8, 0xBEEF, 0xCAFE], 13), decompilePoints(numPoints, data, 4))
-
-	def test_decompilePoints_shouldGuardAgainstBadPointNumbers(self):
-		decompilePoints = table__g_v_a_r.decompilePoints_
-		# 2 points; first run: [3, 9].
-		numPoints = 8
-		self.assertRaises(ttLib.TTLibError, decompilePoints, numPoints, hexdecode("02 01 03 06"), 0)
-
-	def test_decompileDeltas(self):
-		decompileDeltas = table__g_v_a_r.decompileDeltas_
-		# 83 = zero values (0x80), count = 4 (1 + 0x83 & 0x3F)
-		self.assertEqual(([0, 0, 0, 0], 1), decompileDeltas(4, hexdecode("83"), 0))
-		# 41 01 02 FF FF = signed 16-bit values (0x40), count = 2 (1 + 0x41 & 0x3F)
-		self.assertEqual(([258, -1], 5), decompileDeltas(2, hexdecode("41 01 02 FF FF"), 0))
-		# 01 81 07 = signed 8-bit values, count = 2 (1 + 0x01 & 0x3F)
-		self.assertEqual(([-127, 7], 3), decompileDeltas(2, hexdecode("01 81 07"), 0))
-		# combination of all three encodings, preceded and followed by 4 bytes of unused data
-		data = hexdecode("DE AD BE EF 83 40 01 02 01 81 80 DE AD BE EF")
-		self.assertEqual(([0, 0, 0, 0, 258, -127, -128], 11), decompileDeltas(7, data, 4))
-
 
 class GlyphVariationTest(unittest.TestCase):
 	def test_toXML(self):
@@ -202,6 +160,48 @@ class GlyphVariationTest(unittest.TestCase):
 		]
 		self.assertEqual("40 00 00 00 20 00 C0 00 00 00 10 00 00 00 C0 00 40 00",
 				 hexencode(GlyphVariation.compileCoords_(axes, coords)))
+
+	def test_decompilePoints(self):
+		decompilePoints = GlyphVariation.decompilePoints_
+		numPoints = 65536
+		allPoints = range(numPoints)
+		# all points in glyph
+		self.assertEqual((allPoints, 1), decompilePoints(numPoints, hexdecode("00"), 0))
+		# all points in glyph (in overly verbose encoding, not explicitly prohibited by spec)
+		self.assertEqual((allPoints, 2), decompilePoints(numPoints, hexdecode("80 00"), 0))
+		# 2 points; first run: [9, 9+6]
+		self.assertEqual(([9, 15], 4), decompilePoints(numPoints, hexdecode("02 01 09 06"), 0))
+		# 2 points; first run: [0xBEEF, 0xCAFE]. (0x0C0F = 0xCAFE - 0xBEEF)
+		self.assertEqual(([0xBEEF, 0xCAFE], 6), decompilePoints(numPoints, hexdecode("02 81 BE EF 0C 0F"), 0))
+		# 1 point; first run: [7]
+		self.assertEqual(([7], 3), decompilePoints(numPoints, hexdecode("01 00 07"), 0))
+		# 1 point; first run: [7] in overly verbose encoding
+		self.assertEqual(([7], 4), decompilePoints(numPoints, hexdecode("01 80 00 07"), 0))
+		# 1 point; first run: [65535]; requires words to be treated as unsigned numbers
+		self.assertEqual(([65535], 4), decompilePoints(numPoints, hexdecode("01 80 FF FF"), 0))
+		# 4 points; first run: [7, 8]; second run: [255, 257]. 257 is stored in delta-encoded bytes (0xFF + 2).
+		self.assertEqual(([7, 8, 255, 257], 7), decompilePoints(numPoints, hexdecode("04 01 07 01 01 FF 02"), 0))
+		# combination of all encodings, preceded and followed by 4 bytes of unused data
+		data = hexdecode("DE AD DE AD 04 01 07 01 81 BE EF 0C 0F DE AD DE AD")
+		self.assertEqual(([7, 8, 0xBEEF, 0xCAFE], 13), decompilePoints(numPoints, data, 4))
+
+	def test_decompilePoints_shouldGuardAgainstBadPointNumbers(self):
+		decompilePoints = GlyphVariation.decompilePoints_
+		# 2 points; first run: [3, 9].
+		numPoints = 8
+		self.assertRaises(ttLib.TTLibError, decompilePoints, numPoints, hexdecode("02 01 03 06"), 0)
+
+	def test_decompileDeltas(self):
+		decompileDeltas = GlyphVariation.decompileDeltas_
+		# 83 = zero values (0x80), count = 4 (1 + 0x83 & 0x3F)
+		self.assertEqual(([0, 0, 0, 0], 1), decompileDeltas(4, hexdecode("83"), 0))
+		# 41 01 02 FF FF = signed 16-bit values (0x40), count = 2 (1 + 0x41 & 0x3F)
+		self.assertEqual(([258, -1], 5), decompileDeltas(2, hexdecode("41 01 02 FF FF"), 0))
+		# 01 81 07 = signed 8-bit values, count = 2 (1 + 0x01 & 0x3F)
+		self.assertEqual(([-127, 7], 3), decompileDeltas(2, hexdecode("01 81 07"), 0))
+		# combination of all three encodings, preceded and followed by 4 bytes of unused data
+		data = hexdecode("DE AD BE EF 83 40 01 02 01 81 80 DE AD BE EF")
+		self.assertEqual(([0, 0, 0, 0, 258, -127, -128], 11), decompileDeltas(7, data, 4))
 
 	def test_getTupleSize(self):
 		getTupleSize = GlyphVariation.getTupleSize_

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -361,7 +361,7 @@ class GlyphVariationTest(unittest.TestCase):
 				  " 7F 00" + (127 * " 01") +  # first run, contains 128 points: [0 .. 127]
 				  " 7F 80" + (127 * " 01") +  # second run, contains 128 points: [128 .. 511]
 				  " AB 01 00" + (43 * " 00 01"),  # third run, contains 44 points: [512 .. 299]
-				  hexencode(compilePoints(set(xrange(300)))))
+				  hexencode(compilePoints(set(range(300)))))
 
 	def test_decompilePoints(self):
 		decompilePoints = GlyphVariation.decompilePoints_
@@ -397,8 +397,8 @@ class GlyphVariationTest(unittest.TestCase):
 		numPointsInGlyph = 500  # greater than 255, so we also exercise code path for 16-bit encoding
 		compile = GlyphVariation.compilePoints
 		decompile = lambda data: set(GlyphVariation.decompilePoints_(numPointsInGlyph, data, 0)[0])
-		for i in xrange(50):
-			points = set(random.sample(xrange(numPointsInGlyph), 30))
+		for i in range(50):
+			points = set(random.sample(range(numPointsInGlyph), 30))
 			self.assertSetEqual(points, decompile(compile(points)),
 					    "failed round-trip decompile/compilePoints; points=%s" % points)
 
@@ -465,9 +465,9 @@ class GlyphVariationTest(unittest.TestCase):
 		numDeltas = 30
 		compile = GlyphVariation.compileDeltaValues_
 		decompile = lambda data: GlyphVariation.decompileDeltas_(numDeltas, data, 0)[0]
-		for i in xrange(50):
-			deltas = random.sample(xrange(-128, 127), 10)
-			deltas.extend(random.sample(xrange(-32768, 32767), 10))
+		for i in range(50):
+			deltas = random.sample(range(-128, 127), 10)
+			deltas.extend(random.sample(range(-32768, 32767), 10))
 			deltas.extend([0] * 10)
 			random.shuffle(deltas)
 			self.assertListEqual(deltas, decompile(compile(deltas)),

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -92,18 +92,19 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table.sharedCoordCount = 0
 		self.assertEqual([], table.decompileSharedCoords_(["wght"], b""))
 
-	def test_decompileVariations_Skia_I(self):
+	def test_decompileTuples_Skia_I(self):
 		axes = ["wght", "wdth"]
 		table = table__g_v_a_r()
 		table.offsetToCoord = 0
 		table.sharedCoordCount = 8
 		table.axisCount = len(axes)
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
-		self.assertEqual([], table.decompileVariations_(99, sharedCoords, axes, SKIA_GVAR_I))
+		tuples = table.decompileTuples_(99, sharedCoords, axes, SKIA_GVAR_I)
+		self.assertEqual(8, len(tuples))
 
-	def test_decompileVariations_empty(self):
+	def test_decompileTuples_empty(self):
 		table = table__g_v_a_r()
-		self.assertEqual([], table.decompileVariations_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
+		self.assertEqual([], table.decompileTuples_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
 
 	def test_getTupleSize(self):
 		getTupleSize = table__g_v_a_r.getTupleSize_

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -1,0 +1,115 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+import unittest
+from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r, GVAR_HEADER_SIZE, GlyphVariation
+
+
+def hexdecode(s):
+	return bytesjoin([c.decode("hex") for c in s.split()])
+
+# Glyph variation table of uppercase I in the Skia font, as printed in Apple's
+# TrueType spec. The actual Skia font uses a different table for uppercase I.
+# https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gvar.html
+SKIA_GVAR_I = hexdecode(
+	"00 08 00 24 00 33 20 00 00 15 20 01 00 1B 20 02 "
+	"00 24 20 03 00 15 20 04 00 26 20 07 00 0D 20 06 "
+	"00 1A 20 05 00 40 01 01 01 81 80 43 FF 7E FF 7E "
+	"FF 7E FF 7E 00 81 45 01 01 01 03 01 04 01 04 01 "
+	"04 01 02 80 40 00 82 81 81 04 3A 5A 3E 43 20 81 "
+	"04 0E 40 15 45 7C 83 00 0D 9E F3 F2 F0 F0 F0 F0 "
+	"F3 9E A0 A1 A1 A1 9F 80 00 91 81 91 00 0D 0A 0A "
+	"09 0A 0A 0A 0A 0A 0A 0A 0A 0A 0A 0B 80 00 15 81 "
+	"81 00 C4 89 00 C4 83 00 0D 80 99 98 96 96 96 96 "
+	"99 80 82 83 83 83 81 80 40 FF 18 81 81 04 E6 F9 "
+	"10 21 02 81 04 E8 E5 EB 4D DA 83 00 0D CE D3 D4 "
+	"D3 D3 D3 D5 D2 CE CC CD CD CD CD 80 00 A1 81 91 "
+	"00 0D 07 03 04 02 02 02 03 03 07 07 08 08 08 07 "
+	"80 00 09 81 81 00 28 40 00 A4 02 24 24 66 81 04 "
+	"08 FA FA FA 28 83 00 82 02 FF FF FF 83 02 01 01 "
+	"01 84 91 00 80 06 07 08 08 08 08 0A 07 80 03 FE "
+	"FF FF FF 81 00 08 81 82 02 EE EE EE 8B 6D 00")
+
+# Shared coordinates in the Skia font, as printed in Apple's TrueType spec.
+SKIA_SHARED_COORDS = hexdecode(
+	"00 33 20 00 00 15 20 01 00 1B 20 02 00 24 20 03 "
+	"00 15 20 04 00 26 20 07 00 0D 20 06 00 1A 20 05")
+
+class GlyphVariationTableTest(unittest.TestCase):
+	def test_decompileOffsets_shortFormat(self):
+		table = table__g_v_a_r()
+		table.flags = 0
+		table.glyphCount = 5
+		data = b'X' * GVAR_HEADER_SIZE + hexdecode("00 11 22 33 44 55 66 77 88 99 aa bb")
+		self.assertEqual([2*0x0011, 2*0x2233, 2*0x4455, 2*0x6677, 2*0x8899, 2*0xaabb],
+				 table.decompileOffsets_(data))
+
+	def test_decompileOffsets_longFormat(self):
+		table = table__g_v_a_r()
+		table.flags = 1
+		table.glyphCount = 2
+		data = b'X' * GVAR_HEADER_SIZE + hexdecode("00 11 22 33 44 55 66 77 88 99 aa bb")
+		self.assertEqual([0x00112233, 0x44556677, 0x8899aabb],
+				 list(table.decompileOffsets_(data)))
+
+	def test_decompileSharedCoords(self):
+		table = table__g_v_a_r()
+		table.offsetToCoord = 4
+		table.sharedCoordCount = 3
+		data = b"XXXX" + hexdecode(
+			"40 00 00 00 20 00 "
+			"C0 00 00 00 10 00 "
+			"00 00 C0 00 40 00")
+		self.assertEqual([
+			{"wght":  1.0, "wdth": 0.0, "opsz": 0.5},
+			{"wght": -1.0, "wdth": 0.0, "opsz": 0.25},
+			{"wght":  0.0, "wdth": -1.0, "opsz": 1.0}
+		], table.decompileSharedCoords_(["wght", "wdth", "opsz"], data))
+
+	def test_decompileSharedCoords_Skia(self):
+		table = table__g_v_a_r()
+		table.offsetToCoord = 0
+		table.sharedCoordCount = 0
+		sharedCoords = table.decompileSharedCoords_(["wght", "wdth"], SKIA_SHARED_COORDS)
+		self.assertEqual([], sharedCoords)
+
+	def test_decompileSharedCoords_empty(self):
+		table = table__g_v_a_r()
+		table.offsetToCoord = 0
+		table.sharedCoordCount = 0
+		self.assertEqual([], table.decompileSharedCoords_(["wght"], b""))
+
+	def test_decompileVariations_Skia_I(self):
+		axes = ["wght", "wdth"]
+		table = table__g_v_a_r()
+		table.offsetToCoord = 0
+		table.sharedCoordCount = 0
+		table.axisCount = len(axes)
+		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
+		self.assertEqual([], table.decompileVariations_(99, sharedCoords, axes, SKIA_GVAR_I))
+
+	def test_decompileVariations_empty(self):
+		table = table__g_v_a_r()
+		self.assertEqual([], table.decompileVariations_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
+
+	def test_getTupleSize(self):
+		table = table__g_v_a_r()
+		table.axisCount = 3
+		self.assertEqual(4 + table.axisCount * 2, table.getTupleSize(0x8042))
+		self.assertEqual(4 + table.axisCount * 4, table.getTupleSize(0x4077))
+		self.assertEqual(4, table.getTupleSize(0x2077))
+		self.assertEqual(4, table.getTupleSize(11))
+
+
+class GlyphVariationTest(unittest.TestCase):
+	def test_decompilePackedPoints(self):
+		pass
+		# 02 01 00 02 80 40 03 eb 81
+		# 01 00 00 80 80
+		# t = hexdecode("00 82 02 ff ff ff 83 02 01 01 01 84 91")
+		#gvar = GlyphVariation({})
+		#data = hexdecode("01 00 00 80 80")
+		#print('******* %s' % gvar.decompilePackedPoints(data))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -126,7 +126,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		sharedCoords = table.decompileSharedCoords_(axes, SKIA_SHARED_COORDS)
 		tuples = table.decompileTuples_(18, sharedCoords, axes, SKIA_GVAR_I)
 		self.assertEqual(8, len(tuples))
-		self.assertEqual({"wght": (1.0, 1.0, 1.0)}, tuples[0].axes)
+		self.assertEqual({"wght": (0.0, 1.0, 1.0)}, tuples[0].axes)
 		self.assertEqual("257,0 -127,0 -128,58 -130,90 -130,62 -130,67 -130,32 -127,0 257,0 "
 				 "259,14 260,64 260,21 260,69 258,124 0,0 130,0 0,0 0,0",
 				 " ".join(["%d,%d" % c for c in tuples[0].coordinates]))
@@ -135,17 +135,23 @@ class GlyphVariationTableTest(unittest.TestCase):
 		table = table__g_v_a_r()
 		self.assertEqual([], table.decompileTuples_(numPoints=5, sharedCoords=[], axisTags=[], data=b""))
 
+	def test_computeMinMaxCord(self):
+		coord = {"wght": -0.3, "wdth": 0.7}
+		minCoord, maxCoord = table__g_v_a_r.computeMinMaxCoord_(coord)
+		self.assertEqual({"wght": -0.3, "wdth": 0.0}, minCoord)
+		self.assertEqual({"wght": 0.0, "wdth": 0.7}, maxCoord)
 
 class GlyphVariationTest(unittest.TestCase):
 	def test_toXML(self):
 		writer = XMLWriter(StringIO())
-		axes = {"wdth":(0.3, 0.4, 0.5), "wght":(1.0, 1.0, 1.0)}
+		axes = {"wdth":(0.3, 0.4, 0.5), "wght":(0.0, 1.0, 1.0), "opsz":(-0.7, -0.7, 0.0)}
 		g = GlyphVariation(axes, GlyphCoordinates([(9,8), (7,6), (0,0), (-1,-2)]))
-		g.toXML(writer, ["wght", "wdth"])
+		g.toXML(writer, ["wdth", "wght", "opsz"])
 		self.assertEqual([
 			'<tuple>',
-			  '<coord axis="wght" value="1.0"/>',
 			  '<coord axis="wdth" max="0.5" min="0.3" value="0.4"/>',
+			  '<coord axis="wght" value="1.0"/>',
+			  '<coord axis="opsz" value="-0.7"/>',
 			  '<delta pt="0" x="9" y="8"/>',
 			  '<delta pt="1" x="7" y="6"/>',
 			  '<delta pt="3" x="-1" y="-2"/>',
@@ -154,24 +160,28 @@ class GlyphVariationTest(unittest.TestCase):
 
 	def test_toXML_allDeltasZero(self):
 		writer = XMLWriter(StringIO())
-		axes = {"wdth":(0.3, 0.4, 0.5), "wght":(1.0, 1.0, 1.0)}
+		axes = {"wght":(0.0, 1.0, 1.0)}
 		g = GlyphVariation(axes, GlyphCoordinates.zeros(5))
 		g.toXML(writer, ["wght", "wdth"])
 		self.assertEqual([
 			'<tuple>',
 			  '<coord axis="wght" value="1.0"/>',
-			  '<coord axis="wdth" max="0.5" min="0.3" value="0.4"/>',
 			  '<!-- all deltas are (0,0) -->',
 			'</tuple>'
 		], GlyphVariationTest.xml_lines(writer))
 
 	def test_fromXML(self):
 		g = GlyphVariation({}, GlyphCoordinates.zeros(4))
-		g.fromXML("coord", {"axis":"wght", "value":"1.0"}, [])
 		g.fromXML("coord", {"axis":"wdth", "min":"0.3", "value":"0.4", "max":"0.5"}, [])
+		g.fromXML("coord", {"axis":"wght", "value":"1.0"}, [])
+		g.fromXML("coord", {"axis":"opsz", "value":"-0.5"}, [])
 		g.fromXML("delta", {"pt":"1", "x":"33", "y":"44"}, [])
 		g.fromXML("delta", {"pt":"2", "x":"-2", "y":"170"}, [])
-		self.assertEqual({"wght":(1.0, 1.0, 1.0), "wdth":(0.3, 0.4, 0.5)}, g.axes)
+		self.assertEqual({
+			"wdth":( 0.3,  0.4, 0.5),
+			"wght":( 0.0,  1.0, 1.0),
+			"opsz":(-0.5, -0.5, 0.0)
+		}, g.axes)
 		self.assertEqual("0,0 33,44 -2,170 0,0", " ".join(["%d,%d" % c for c in g.coordinates]))
 
 	def test_compileCoord(self):
@@ -181,9 +191,9 @@ class GlyphVariationTest(unittest.TestCase):
 		self.assertEqual("C0 00", hexencode(gvar.compileCoord(["wght"])))
 
 	def test_compileIntermediateCoord(self):
-		gvar = GlyphVariation({"wght": (-1.0, -1.0, -1.0), "wdth": (0.4, 0.5, 0.6)}, GlyphCoordinates.zeros(4))
-		self.assertEqual("C0 00 19 9A C0 00 26 66", hexencode(gvar.compileIntermediateCoord(["wght", "wdth"])))
-		self.assertEqual("19 9A C0 00 26 66 C0 00", hexencode(gvar.compileIntermediateCoord(["wdth", "wght"])))
+		gvar = GlyphVariation({"wght": (-1.0, -1.0, 0.0), "wdth": (0.4, 0.5, 0.6)}, GlyphCoordinates.zeros(4))
+		self.assertEqual("C0 00 19 9A 00 00 26 66", hexencode(gvar.compileIntermediateCoord(["wght", "wdth"])))
+		self.assertEqual("19 9A C0 00 26 66 00 00", hexencode(gvar.compileIntermediateCoord(["wdth", "wght"])))
 		self.assertEqual(None, gvar.compileIntermediateCoord(["wght"]))
 		self.assertEqual("19 9A 26 66", hexencode(gvar.compileIntermediateCoord(["wdth"])))
 

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -114,7 +114,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		# {"wght":1.0, "wdth":0.7} is shared 3 times; {"wght":1.0, "wdth":0.8} is shared twice.
 		# Min and max values are not part of the shared coordinate pool and should get ignored.
 		result = table.compileSharedCoords_(font, ["wght", "wdth"])
-		self.assertEquals(["40 00 2C CD", "40 00 33 33"], [hexencode(c) for c in result])
+		self.assertEqual(["40 00 2C CD", "40 00 33 33"], [hexencode(c) for c in result])
 
 	def test_decompileSharedCoords_Skia(self):
 		table = table__g_v_a_r()
@@ -365,17 +365,17 @@ class GlyphVariationTest(unittest.TestCase):
 
 	def test_compilePoints(self):
 		compilePoints = GlyphVariation.compilePoints
-		self.assertEquals("01 00 07", hexencode(compilePoints(set([7]))))
-		self.assertEquals("01 80 FF FF", hexencode(compilePoints(set([65535]))))
-		self.assertEquals("02 01 09 06", hexencode(compilePoints(set([9, 15]))))
-		self.assertEquals("06 05 07 01 F7 02 01 F2", hexencode(compilePoints(set([7, 8, 255, 257, 258, 500]))))
-		self.assertEquals("03 01 07 01 80 01 F4", hexencode(compilePoints(set([7, 8, 500]))))
-		self.assertEquals("04 01 07 01 81 BE EF 0C 0F", hexencode(compilePoints(set([7, 8, 0xBEEF, 0xCAFE]))))
-		self.assertEquals("81 2C" +  # 300 points (0x12c) in total
-				  " 7F 00" + (127 * " 01") +  # first run, contains 128 points: [0 .. 127]
-				  " 7F 80" + (127 * " 01") +  # second run, contains 128 points: [128 .. 511]
-				  " AB 01 00" + (43 * " 00 01"),  # third run, contains 44 points: [512 .. 299]
-				  hexencode(compilePoints(set(range(300)))))
+		self.assertEqual("01 00 07", hexencode(compilePoints(set([7]))))
+		self.assertEqual("01 80 FF FF", hexencode(compilePoints(set([65535]))))
+		self.assertEqual("02 01 09 06", hexencode(compilePoints(set([9, 15]))))
+		self.assertEqual("06 05 07 01 F7 02 01 F2", hexencode(compilePoints(set([7, 8, 255, 257, 258, 500]))))
+		self.assertEqual("03 01 07 01 80 01 F4", hexencode(compilePoints(set([7, 8, 500]))))
+		self.assertEqual("04 01 07 01 81 BE EF 0C 0F", hexencode(compilePoints(set([7, 8, 0xBEEF, 0xCAFE]))))
+		self.assertEqual("81 2C" +  # 300 points (0x12c) in total
+				 " 7F 00" + (127 * " 01") +  # first run, contains 128 points: [0 .. 127]
+				 " 7F 80" + (127 * " 01") +  # second run, contains 128 points: [128 .. 511]
+				 " AB 01 00" + (43 * " 00 01"),  # third run, contains 44 points: [512 .. 299]
+				 hexencode(compilePoints(set(range(300)))))
 
 	def test_decompilePoints(self):
 		decompilePoints = GlyphVariation.decompilePoints_

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -131,6 +131,15 @@ class GlyphVariationTest(unittest.TestCase):
 			'</tuple>'
 		], GlyphVariationTest.xml_lines(writer))
 
+	def test_fromXML(self):
+		g = GlyphVariation({}, GlyphCoordinates.zeros(4))
+		g.fromXML("coord", {"axis":"wght", "value":"1.0"}, [])
+		g.fromXML("coord", {"axis":"wdth", "min":"0.3", "value":"0.4", "max":"0.5"}, [])
+		g.fromXML("delta", {"pt":"1", "x":"33", "y":"44"}, [])
+		g.fromXML("delta", {"pt":"2", "x":"-2", "y":"170"}, [])
+		self.assertEqual({"wght":(1.0, 1.0, 1.0), "wdth":(0.3, 0.4, 0.5)}, g.axes)
+		self.assertEqual("0,0 33,44 -2,170 0,0", " ".join(["%d,%d" % c for c in g.coordinates]))
+
 	def test_decompileCoord(self):
 		decompileCoord = GlyphVariation.decompileCoord_
 		data = hexdecode("DE AD C0 00 20 00 DE AD")

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -31,8 +31,9 @@ SKIA_GVAR_I = hexdecode(
 
 # Shared coordinates in the Skia font, as printed in Apple's TrueType spec.
 SKIA_SHARED_COORDS = hexdecode(
-	"00 33 20 00 00 15 20 01 00 1B 20 02 00 24 20 03 "
-	"00 15 20 04 00 26 20 07 00 0D 20 06 00 1A 20 05")
+	"40 00 00 00 C0 00 00 00 00 00 40 00 00 00 C0 00 "
+	"C0 00 C0 00 40 00 C0 00 40 00 40 00 C0 00 40 00")
+
 
 class GlyphVariationTableTest(unittest.TestCase):
 	def test_decompileOffsets_shortFormat(self):
@@ -72,9 +73,18 @@ class GlyphVariationTableTest(unittest.TestCase):
 	def test_decompileSharedCoords_Skia(self):
 		table = table__g_v_a_r()
 		table.offsetToCoord = 0
-		table.sharedCoordCount = 0
+		table.sharedCoordCount = 8
 		sharedCoords = table.decompileSharedCoords_(["wght", "wdth"], SKIA_SHARED_COORDS)
-		self.assertEqual([], sharedCoords)
+		self.assertEqual([
+			{"wght": 1.0, "wdth": 0.0},
+			{"wght": -1.0, "wdth": 0.0},
+			{"wght": 0.0, "wdth": 1.0},
+			{"wght": 0.0, "wdth": -1.0},
+			{"wght": -1.0, "wdth": -1.0},
+			{"wght": 1.0, "wdth": -1.0},
+			{"wght": 1.0, "wdth": 1.0},
+			{"wght": -1.0, "wdth": 1.0}
+		], sharedCoords)
 
 	def test_decompileSharedCoords_empty(self):
 		table = table__g_v_a_r()

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -159,6 +159,11 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual({"wght": 0.0, "wdth": 0.7}, maxCoord)
 
 class GlyphVariationTest(unittest.TestCase):
+	def __init__(self, methodName):
+		unittest.TestCase.__init__(self, methodName)
+		if not hasattr(self, "assertSetEqual"):  # only in Python 2.7 and later
+			self.assertSetEqual = self.assertEqual
+
 	def test_equal(self):
 		gvar1 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, [(0,0), (9,8), (7,6)])
 		gvar2 = GlyphVariation({"wght":(0.0, 1.0, 1.0)}, [(0,0), (9,8), (7,6)])
@@ -443,16 +448,12 @@ class GlyphVariationTest(unittest.TestCase):
 		numPointsInGlyph = 500  # greater than 255, so we also exercise code path for 16-bit encoding
 		compile = GlyphVariation.compilePoints
 		decompile = lambda data: set(GlyphVariation.decompilePoints_(numPointsInGlyph, data, 0)[0])
-		if hasattr(self, "assertSetEqual"):  # only in Python 2.7 and later
-			assertSetEqual = self.assertSetEqual
-		else:
-			assertSetEqual = self.assertEqual
 		for i in range(50):
 			points = set(random.sample(range(numPointsInGlyph), 30))
-			assertSetEqual(points, decompile(compile(points)),
-				       "failed round-trip decompile/compilePoints; points=%s" % points)
+			self.assertSetEqual(points, decompile(compile(points)),
+					    "failed round-trip decompile/compilePoints; points=%s" % points)
 		allPoints = set(range(numPointsInGlyph))
-		assertSetEqual(allPoints, decompile(compile(allPoints)))
+		self.assertSetEqual(allPoints, decompile(compile(allPoints)))
 
 	def test_compileDeltas(self):
 		gvar = GlyphVariation({}, [(0,0), (1, 0), (2, 0), (3, 3)])

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -92,10 +92,6 @@ class GlyphVariationTableTest(unittest.TestCase):
 		self.assertEqual([gvar1, gvar2], table.decompileGlyph_(numPoints, {}, axisTags, data))
 
 	def test_compileSharedCoords(self):
-		class FakeFont:
-			def getGlyphOrder(self):
-				return ["A", "B", "C"]
-		font = FakeFont()
 		table = table__g_v_a_r()
 		table.variations = {}
 		deltas = [None] * 4
@@ -113,7 +109,7 @@ class GlyphVariationTableTest(unittest.TestCase):
 		]
 		# {"wght":1.0, "wdth":0.7} is shared 3 times; {"wght":1.0, "wdth":0.8} is shared twice.
 		# Min and max values are not part of the shared coordinate pool and should get ignored.
-		result = table.compileSharedCoords_(font, ["wght", "wdth"])
+		result = table.compileSharedCoords_(["wght", "wdth"])
 		self.assertEqual(["40 00 2C CD", "40 00 33 33"], [hexencode(c) for c in result])
 
 	def test_decompileSharedCoords_Skia(self):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -271,8 +271,8 @@ class GlyphVariationTest(unittest.TestCase):
 		tuple, data = gvar.compile(axisTags, sharedCoordIndices, sharedPoints=None)
 		# len(data)=13; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedCoord=[]; intermediateCoord=[]
-		self.assertEqual("00 0D 20 77", hexencode(tuple))
-		self.assertEqual("03 02 00 01 01 "  # 3 points: [0, 1, 2]
+		self.assertEqual("00 09 20 77", hexencode(tuple))
+		self.assertEqual("00 "              # all points in glyph
 				 "02 07 08 09 "     # deltaX: [7, 8, 9]
 				 "02 04 05 06",     # deltaY: [4, 5, 6]
 				 hexencode(data))
@@ -285,8 +285,8 @@ class GlyphVariationTest(unittest.TestCase):
 		tuple, data = gvar.compile(axisTags, sharedCoordIndices, sharedPoints=None)
 		# len(data)=13; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedCoord=[]; intermediateCoord=[(0.0, 0.0), (1.0, 1.0)]
-		self.assertEqual("00 0D 60 77 00 00 00 00 40 00 40 00", hexencode(tuple))
-		self.assertEqual("03 02 00 01 01 "  # 3 points: [0, 1, 2]
+		self.assertEqual("00 09 60 77 00 00 00 00 40 00 40 00", hexencode(tuple))
+		self.assertEqual("00 "              # all points in glyph
 				 "02 07 08 09 "     # deltaX: [7, 8, 9]
 				 "02 04 05 06",     # deltaY: [4, 5, 6]
 				 hexencode(data))
@@ -322,8 +322,8 @@ class GlyphVariationTest(unittest.TestCase):
 		tuple, data = gvar.compile(axisTags, sharedCoordIndices={}, sharedPoints=None)
 		# len(data)=13; flags=PRIVATE_POINT_NUMBERS|EMBEDDED_TUPLE_COORD
 		# embeddedCoord=[(0.5, 0.8)]; intermediateCoord=[]
-		self.assertEqual("00 0D A0 00 20 00 33 33", hexencode(tuple))
-		self.assertEqual("03 02 00 01 01 "  # 3 points: [0, 1, 2]
+		self.assertEqual("00 09 A0 00 20 00 33 33", hexencode(tuple))
+		self.assertEqual("00 "              # all points in glyph
 				 "02 07 08 09 "     # deltaX: [7, 8, 9]
 				 "02 04 05 06",     # deltaY: [4, 5, 6]
 				 hexencode(data))
@@ -335,8 +335,8 @@ class GlyphVariationTest(unittest.TestCase):
 		tuple, data = gvar.compile(axisTags, sharedCoordIndices={}, sharedPoints=None)
 		# len(data)=13; flags=PRIVATE_POINT_NUMBERS|INTERMEDIATE_TUPLE|EMBEDDED_TUPLE_COORD
 		# embeddedCoord=(0.5, 0.8); intermediateCoord=[(0.4, 0.7), (0.6, 0.9)]
-		self.assertEqual("00 0D E0 00 20 00 33 33 19 9A 2C CD 26 66 39 9A", hexencode(tuple))
-		self.assertEqual("03 02 00 01 01 "  # 3 points: [0, 1, 2]
+		self.assertEqual("00 09 E0 00 20 00 33 33 19 9A 2C CD 26 66 39 9A", hexencode(tuple))
+		self.assertEqual("00 "              # all points in glyph
 				 "02 07 08 09 "     # deltaX: [7, 8, 9]
 				 "02 04 05 06",     # deltaY: [4, 5, 6]
 				 hexencode(data))
@@ -380,6 +380,7 @@ class GlyphVariationTest(unittest.TestCase):
 
 	def test_compilePoints(self):
 		compilePoints = lambda p: GlyphVariation.compilePoints(set(p), numPointsInGlyph=999)
+		self.assertEqual("00", hexencode(compilePoints(range(999))))  # all points in glyph
 		self.assertEqual("01 00 07", hexencode(compilePoints([7])))
 		self.assertEqual("01 80 FF FF", hexencode(compilePoints([65535])))
 		self.assertEqual("02 01 09 06", hexencode(compilePoints([9, 15])))

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -352,6 +352,14 @@ class GlyphVariationTest(unittest.TestCase):
 		data = deHexStr("DE AD C0 00 20 00 DE AD")
 		self.assertEqual(({"wght": -1.0, "wdth": 0.5}, 6), decompileCoord(["wght", "wdth"], data, 2))
 
+	def test_decompileCoord_roundTrip(self):
+		# Make sure we are not affected by https://github.com/behdad/fonttools/issues/286
+		data = deHexStr("7F B9 80 35")
+		values, _ = GlyphVariation.decompileCoord_(["wght", "wdth"], data, 0)
+		axisValues = dict([(axis, (val, val, val)) for axis, val in  values.items()])
+		gvar = GlyphVariation(axisValues, GlyphCoordinates.zeros(4))
+		self.assertEqual("7F B9 80 35", hexencode(gvar.compileCoord(["wght", "wdth"])))
+
 	def test_decompileCoords(self):
 		decompileCoords = GlyphVariation.decompileCoords_
 		axes = ["wght", "wdth", "opsz"]


### PR DESCRIPTION
After round-tripping through TTX, the font rendering of MacOS X 10.9.5 can display
Skia.ttf, BuffaloGalRegular.ttf and JamRegular.ttf just fine including glyph variations.

Screen shot:
![screen shot 2015-05-05 at 4 59 21 pm](https://cloud.githubusercontent.com/assets/1527880/7475482/213253c8-f348-11e4-94e1-bb052694ad7a.png)

