### PR TITLE
[macCreatorType] disable workaround in py27 for setting as well getting

### DIFF
--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -29,10 +29,4 @@ def getMacCreatorAndType(path):
 
 def setMacCreatorAndType(path, fileCreator, fileType):
 	if MacOS is not None:
-		if sys.version_info[:2] < (2, 7) and sys.byteorder == "little":
-			# work around bug in MacOS.SetCreatorAndType() on intel:
-			# http://bugs.python.org/issue1594
-			# (fixed with Python 2.7)
-			fileCreator = _reverseString(fileCreator)
-			fileType = _reverseString(fileType)
 		MacOS.SetCreatorAndType(path, fileCreator, fileType)

--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -29,9 +29,10 @@ def getMacCreatorAndType(path):
 
 def setMacCreatorAndType(path, fileCreator, fileType):
 	if MacOS is not None:
-		if sys.byteorder == "little":
+		if sys.version_info[:2] < (2, 7) and sys.byteorder == "little":
 			# work around bug in MacOS.SetCreatorAndType() on intel:
 			# http://bugs.python.org/issue1594
+			# (fixed with Python 2.7)
 			fileCreator = _reverseString(fileCreator)
 			fileType = _reverseString(fileType)
 		MacOS.SetCreatorAndType(path, fileCreator, fileType)


### PR DESCRIPTION
I know nowadays one no longer needs to set the creator and type on a mac, but because we already fixed the "getting" part, we may as well fix the "setting" one...