### PR TITLE
[py23] simulate "wide" unichr and ord on "narrow" UCS2-only Python 2

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -23,7 +23,6 @@ try:
 
 		def unichr(i):
 			"""
-			
 			Return the unicode character whose Unicode code is the integer 'i'.
 			The valid range is 0 to 0x10FFFF inclusive.
 
@@ -55,7 +54,6 @@ try:
 
 		def byteord(c):
 			"""
-			Workaround for Python 2 "narrow" builds (UCS2 Unicode).
 			Given a 8-bit or unicode character, return an integer representing the
 			Unicode code point of the character. If a unicode argument is given, the
 			character's code point must be in the range 0 to 0x10FFFF inclusive.

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -1,6 +1,7 @@
 """Python 2/3 compat layer."""
 
 from __future__ import print_function, division, absolute_import
+import sys
 
 try:
 	basestring
@@ -14,9 +15,77 @@ except NameError:
 
 try:
 	unichr
+
+	if sys.maxunicode < 0x10FFFF:
+		# workarounds for Python 2 "narrow" builds with UCS2-only support.
+
+		_narrow_unichr = unichr
+
+		def unichr(i):
+			"""
+			
+			Return the unicode character whose Unicode code is the integer 'i'.
+			The valid range is 0 to 0x10FFFF inclusive.
+
+			>>> _narrow_unichr(0xFFFF + 1)
+			Traceback (most recent call last):
+			  File "<stdin>", line 1, in ?
+			ValueError: unichr() arg not in range(0x10000) (narrow Python build)
+			>>> unichr(0xFFFF + 1) == u'\U00010000'
+			True
+			>>> unichr(1114111) == u'\U0010FFFF'
+			True
+			>>> unichr(0x10FFFF + 1)
+			Traceback (most recent call last):
+			  File "<stdin>", line 1, in ?
+			ValueError: unichr() arg not in range(0x110000)
+			"""
+			try:
+				return _narrow_unichr(i)
+			except ValueError:
+				try:
+					padded_hex_str = hex(i)[2:].zfill(8)
+					escape_str = "\\U" + padded_hex_str
+					return escape_str.decode("unicode-escape")
+				except UnicodeDecodeError:
+					raise ValueError('unichr() arg not in range(0x110000)')
+
+		import re
+		_unicode_escape_RE = re.compile(r'\\U[A-Fa-f0-9]{8}')
+
+		def byteord(c):
+			"""
+			Workaround for Python 2 "narrow" builds (UCS2 Unicode).
+			Given a 8-bit or unicode character, return an integer representing the
+			Unicode code point of the character. If a unicode argument is given, the
+			character's code point must be in the range 0 to 0x10FFFF inclusive.
+
+			>>> ord(u'\U00010000')
+			Traceback (most recent call last):
+			  File "<stdin>", line 1, in ?
+			TypeError: ord() expected a character, but string of length 2 found
+			>>> byteord(u'\U00010000') == 0xFFFF + 1
+			True
+			>>> byteord(u'\U0010FFFF') == 1114111
+			True
+			"""
+			try:
+				return ord(c)
+			except TypeError as e:
+				try:
+					escape_str = c.encode('unicode-escape')
+					if not _unicode_escape_RE.match(escape_str):
+						raise
+					hex_str = escape_str[3:]
+					return int(hex_str, 16)
+				except:
+					raise TypeError(e)
+
+	else:
+		byteord = ord
 	bytechr = chr
-	byteord = ord
-except:
+
+except NameError:
 	unichr = chr
 	def bytechr(n):
 		return bytes([n])
@@ -79,3 +148,8 @@ else:
 
 	def bytesjoin(iterable, joiner=b''):
 		return tobytes(joiner).join(tobytes(item) for item in iterable)
+
+
+if __name__ == "__main__":
+	import doctest, sys
+	sys.exit(doctest.testmod().failed)


### PR DESCRIPTION
I drop this here in case anybody may be interested.

As you know, when working with non-BMP unicode characters on a Python 2 which was built with UCS-2 Unicode support (i.e. the so called "narrow" builds), then the built-in `unichr` and the corresponding `ord` functions are limited to the range(0x10000). This is the case of most Python 2 configurations, including the OS X system Python and the Windows installer from Python.org.
This is quite annoying, given that Python 3 is always configured with UCS-4 support.

The py23 compatibility layer inside the misc sub-package could be the right place to add two simple workarounds which extends the unichr and byteord range to the full Unicode (0x110000), even on narrow Python 2 builds.

For example, think about looking up the built-in unicodedata module for the name of a Unicode character:

```python
>>> unicodedata.name(unichr(0x10000))
'LINEAR B SYLLABLE B008 A'
```

The line above works fine on Python 3 (of course, using our `unichr` alias of the `chr` built-in), but will fail on the majority of Python 2 builds.

What do you think? Does it seem too hackish?