### PR TITLE
[glyf] fixed 'noname'

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -53,7 +53,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			warnings.warn("too much 'glyf' table data: expected %d, received %d bytes" %
 					(next, len(data)))
 		if noname:
-			warnings.warn('%s glyphs have no name' % i)
+			warnings.warn('%s glyphs have no name' % noname)
 		if ttFont.lazy is False: # Be lazy for None and True
 			for glyph in self.glyphs.values():
 				glyph.expand(self)


### PR DESCRIPTION
there's a little typo in the warning message which prints the number of glyphs which are assigned a dummy glyph name.