### PR TITLE
[setup.py] use setuptools if available, or fall back to distutils

### DIFF
--- a/Lib/fontTools/inspect.py
+++ b/Lib/fontTools/inspect.py
@@ -251,7 +251,9 @@ class Inspect(object):
 		self.scrolled_window.add(self.treeview)
 		self.window.show_all()
 
-def main(args):
+def main(args=None):
+	if args is None:
+		args = sys.argv[1:]
 	if len(args) < 1:
 		print("usage: pyftinspect font...", file=sys.stderr)
 		sys.exit(1)
@@ -260,4 +262,4 @@ def main(args):
 	gtk.main()
 
 if __name__ == "__main__":
-	main(sys.argv[1:])
+	main()

--- a/Lib/fontTools/merge.py
+++ b/Lib/fontTools/merge.py
@@ -920,7 +920,10 @@ __all__ = [
   'main'
 ]
 
-def main(args):
+def main(args=None):
+
+	if args is None:
+		args = sys.argv[1:]
 
 	log = Logger()
 	args = log.parse_opts(args)
@@ -942,4 +945,4 @@ def main(args):
 	log.lapse("make one with everything(TOTAL TIME)")
 
 if __name__ == "__main__":
-	main(sys.argv[1:])
+	main()

--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -2644,7 +2644,10 @@ def parse_gids(s):
 def parse_glyphs(s):
     return s.replace(',', ' ').split()
 
-def main(args):
+def main(args=None):
+
+    if args is None:
+        args = sys.argv[1:]
 
     if '--help' in args:
         print(__doc__)
@@ -2768,4 +2771,4 @@ __all__ = [
 ]
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -309,7 +309,9 @@ def waitForKeyPress():
 		pass
 
 
-def main(args):
+def main(args=None):
+	if args is None:
+		args = sys.argv[1:]
 	jobs, options = parseOptions(args)
 	try:
 		process(jobs, options)
@@ -332,4 +334,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-	main(sys.argv[1:])
+	main()

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,22 @@
 
 from __future__ import print_function
 import os, sys
-from distutils.core import setup, Extension
-from distutils.command.build_ext import build_ext
 
+# if setuptools is not installed, fall back to distutils
 try:
-	# load py2exe distutils extension, if available
-	import py2exe
+	from setuptools import setup
 except ImportError:
-	pass
+	from distutils.core import setup
+	distutils_scripts = [
+		"Tools/ttx", "Tools/pyftsubset", "Tools/pyftinspect", "Tools/pyftmerge"]
+else:
+	distutils_scripts = []
 
 try:
 	import xml.parsers.expat
 except ImportError:
 	print("*** Warning: FontTools needs PyXML, see:")
 	print("        http://sourceforge.net/projects/pyxml/")
-
-
-class build_ext_optional(build_ext):
-	"""build_ext command which doesn't abort when it fails."""
-	def build_extension(self, ext):
-		# Skip extensions which cannot be built
-		try:
-			build_ext.build_extension(self, ext)
-		except:
-			self.announce(
-				'*** WARNING: Building of extension "%s" '
-				'failed: %s' %
-				(ext.name, sys.exc_info()[1]))
 
 
 if sys.version_info > (2, 3, 0, 'alpha', 1):
@@ -71,6 +60,7 @@ setup(
 		long_description = long_description,
 		
 		packages = [
+			"",
 			"fontTools",
 			"fontTools.encodings",
 			"fontTools.misc",
@@ -80,8 +70,15 @@ setup(
 		],
 		package_dir = {'': 'Lib'},
 		extra_path = 'FontTools',
-		scripts = ["Tools/ttx", "Tools/pyftsubset", "Tools/pyftinspect", "Tools/pyftmerge"],
-		cmdclass = {"build_ext": build_ext_optional},
 		data_files = [('share/man/man1', ["Doc/ttx.1"])],
+		scripts = distutils_scripts,
+		entry_points = {
+				'console_scripts': [
+					"ttx = fontTools.ttx:main",
+					"pyftsubset = fontTools.subset:main",
+					"pyftmerge = fontTools.merge:main",
+					"pyftinspect = fontTools.inspect:main"
+				]
+			},
 		**classifiers
 	)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
 		long_description = long_description,
 		
 		packages = [
-			"",
 			"fontTools",
 			"fontTools.encodings",
 			"fontTools.misc",
@@ -68,6 +67,7 @@ setup(
 			"fontTools.ttLib",
 			"fontTools.ttLib.tables",
 		],
+		py_modules = ['sstruct', 'xmlWriter'],
 		package_dir = {'': 'Lib'},
 		extra_path = 'FontTools',
 		data_files = [('share/man/man1', ["Doc/ttx.1"])],


### PR DESCRIPTION
This patch addresses issue https://github.com/behdad/fonttools/issues/272

If setuptools raises an ImportError, then it falls back to the old distutils method.

I modified the four scripts so that they can work as setuptools 'console_scripts', in which the main function takes no arguments.

I also added an empty identifier "" in the 'packages' argument of setup function, otherwise the 
standalone sstruct.py and xmlWriter.py module -- which we have put back at the root of Lib for legacy -- would not be correctly installed.

I also removed py2exe since that is made redundant by the setuptools 'console_scripts' approach. This in fact will automagically create Windows executables (.exe) for each script using the specified entry point (I think this is really cool!).

Finally, I removed the custom 'build_ext' command which is no longer needed, since the "Src/eexecOpmodule.c" extension module was removed some time ago from behdad's fork.

