### PR TITLE
[maxp] calculate correct maxSizeOfInstructions

### DIFF
--- a/Lib/fontTools/ttLib/tables/_m_a_x_p.py
+++ b/Lib/fontTools/ttLib/tables/_m_a_x_p.py
@@ -73,6 +73,7 @@ class table__m_a_x_p(DefaultTable.DefaultTable):
 		maxCompositeContours = 0
 		maxComponentElements = 0
 		maxComponentDepth = 0
+		maxSizeOfInstructions = 0
 		allXMaxIsLsb = 1
 		for glyphName in ttFont.getGlyphOrder():
 			g = glyfTable[glyphName]
@@ -93,6 +94,11 @@ class table__m_a_x_p(DefaultTable.DefaultTable):
 					maxCompositeContours = max(maxCompositeContours, nContours)
 					maxComponentElements = max(maxComponentElements, len(g.components))
 					maxComponentDepth = max(maxComponentDepth, componentDepth)
+				if hasattr(g, 'program'):
+					instructions = g.program.getBytecode()
+					numInstructions = len(instructions)
+					maxSizeOfInstructions = max(maxSizeOfInstructions, numInstructions)
+		self.maxSizeOfInstructions = maxSizeOfInstructions
 		if xMin == +INFINITY:
 			headTable.xMin = 0
 			headTable.yMin = 0


### PR DESCRIPTION
Fixes an issue whereby VTT calculates an incorrect value, and MS Font
Validator raises a warning message (W1900).

VTT wrongly includes the length of font-wide hinting tables (fpgm, prep)
in the computation, whereas the spec clearly says that this value is:

"the maximum size in bytes for all of the instructions associated with a
particular glyph."

https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6maxp.html