### PR TITLE
[ttx] use TTX mtime for 'modified' (default), optionally "--recalc-timestamp"

### DIFF
--- a/Lib/fontTools/misc/encodingTools.py
+++ b/Lib/fontTools/misc/encodingTools.py
@@ -1,4 +1,4 @@
-"""fontTools.misc.timeTools.py -- tools for working with OpenType encodings.
+"""fontTools.misc.encodingTools.py -- tools for working with OpenType encodings.
 """
 
 from __future__ import print_function, division, absolute_import

--- a/Lib/fontTools/misc/timeTools.py
+++ b/Lib/fontTools/misc/timeTools.py
@@ -17,3 +17,6 @@ def timestampFromString(value):
 
 def timestampNow():
 	return int(time.time() - epoch_diff)
+
+def timestampSinceEpoch(value):
+	return int(value - epoch_diff)


### PR DESCRIPTION
This was discussed some time ago both on the [mailing list](https://groups.google.com/forum/#!searchin/fonttools/modified/fonttools/Q4X9wDz8YLA/tfnTWwjTlawJ
) and here https://github.com/behdad/fonttools/issues/46.

With this patch, the default behavior would be that ttx uses the TTX file modified timestamp as the OpenType font's `head.modified` value.
Optionally, one can also have the timestamp recalculated based on the current time (though I don't see why one would like to do that...)

Since "-t" is taken, I used another long option, "--recalc-timestamp", i.e. the same used in pyftsubset.

Please, let me know if think the TTX file modification time shouldn't be the default.
Thanks.

C. 

