### PR TITLE
fix xmlWriter and _l_t_a_g tests failing on Windows because of \r\n

### DIFF
--- a/Lib/fontTools/misc/xmlWriter_test.py
+++ b/Lib/fontTools/misc/xmlWriter_test.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+import os
 import unittest
 from .xmlWriter import XMLWriter
 
-HEADER = b'<?xml version="1.0" encoding="UTF-8"?>\n'
+linesep = tobytes(os.linesep)
+HEADER = b'<?xml version="1.0" encoding="UTF-8"?>' + linesep
 
 class TestXMLWriter(unittest.TestCase):
 
@@ -15,29 +17,30 @@ class TestXMLWriter(unittest.TestCase):
 	def test_comment_multiline(self):
 		writer = XMLWriter(StringIO())
 		writer.comment("Hello world\nHow are you?")
-		self.assertEqual(HEADER + b"<!-- Hello world\n     How are you? -->", writer.file.getvalue())
+		self.assertEqual(HEADER + b"<!-- Hello world" + linesep + b"     How are you? -->",
+				 writer.file.getvalue())
 
 	def test_encoding_default(self):
 		writer = XMLWriter(StringIO())
-		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>\n',
+		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_utf8(self):
 		# https://github.com/behdad/fonttools/issues/246
 		writer = XMLWriter(StringIO(), encoding="utf8")
-		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>\n',
+		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_UTF_8(self):
 		# https://github.com/behdad/fonttools/issues/246
 		writer = XMLWriter(StringIO(), encoding="UTF-8")
-		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>\n',
+		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_UTF8(self):
 		# https://github.com/behdad/fonttools/issues/246
 		writer = XMLWriter(StringIO(), encoding="UTF8")
-		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>\n',
+		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_other(self):
@@ -58,7 +61,8 @@ class TestXMLWriter(unittest.TestCase):
 		writer.newline()
 		writer.dedent()
 		writer.write("baz")
-		self.assertEqual(HEADER + b"foo\n  bar\nbaz", writer.file.getvalue())
+		self.assertEqual(HEADER + bytesjoin(["foo", "  bar", "baz"], linesep),
+				 writer.file.getvalue())
 
 	def test_writecdata(self):
 		writer = XMLWriter(StringIO())
@@ -85,8 +89,7 @@ class TestXMLWriter(unittest.TestCase):
 		    "66756c20 67726f75 70206f66 206c6574",
 		    "74657273 2c206e6f 74206120 67726f75",
 		    "70206f66 20626561 75746966 756c206c",
-		    "65747465 72732e  \n"], joiner=b'\n'), writer.file.getvalue())
-
+		    "65747465 72732e  ", ""], joiner=linesep), writer.file.getvalue())
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc.xmlWriter import XMLWriter
+import os
 import struct
 import unittest
 from ._l_t_a_g import table__l_t_a_g
@@ -33,14 +34,14 @@ class Test_l_t_a_g(unittest.TestCase):
 		table = table__l_t_a_g()
 		table.decompile(self.DATA_, ttFont=None)
 		table.toXML(writer, ttFont=None)
-		expected = "\n".join([
+		expected = os.linesep.join([
 			'<?xml version="1.0" encoding="UTF-8"?>',
 			'<version value="1"/>',
 			'<flags value="0"/>',
 			'<LanguageTag tag="en"/>',
 			'<LanguageTag tag="zh-Hant"/>',
 			'<LanguageTag tag="zh"/>'
-		]) + "\n"
+		]) + os.linesep
 		self.assertEquals(expected.encode("utf_8"), writer.file.getvalue())
 
 


### PR DESCRIPTION
@brawer the explicit "\n" newline separator was making some of the unittests fail on Windows, where python uses "\r\n" instead. I replaced them with `os.linesep`.

cheers,

C.