### PR TITLE
[.travis.yml] pip install unittest2 for python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "pypy"
   - "pypy3"
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
   - make install
 script:
   - make check


### PR DESCRIPTION
I'm struggling to find a single unittest idiom that would work for all python versions between 2.6 and 3.4.
The best solution I found is to install the `unittest2` package when Python version is 2.6.
That will backport all the new unittest features introduced in Python 2.7 and 3.x.
For example, I want to skip tests in woff2 module if brotli is not installed, instead of fail. Or I want to assert that an exception message matches a specific regular expression pattern. All this is not available in python2.6 unittest built-in module.
The pip installer is already on the Travis virtual machine, so we simply need to check if the Travis python version is 2.6, and then do a pip install `unittest2`.