### PR TITLE
[GX] Support 'avar' table

### DIFF
--- a/Doc/documentation.html
+++ b/Doc/documentation.html
@@ -42,7 +42,7 @@ When using TTX from the command line there are a bunch of extra options, these a
 The following tables are currently supported:
 <BLOCKQUOTE><TT>
 <!-- begin table list -->
-BASE, CBDT, CBLC, CFF, COLR, CPAL, DSIG, EBDT, EBLC, FFTM, GDEF, GMAP, GPKG, GPOS, GSUB, JSTF, LTSH, MATH, META, OS/2, SING, SVG, TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS, TSIV, VDMX, VORG, cmap, cvt, feat, fpgm, fvar, gasp, glyf, gvar, hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, name, post, prep, sbix, vhea and vmtx
+BASE, CBDT, CBLC, CFF, COLR, CPAL, DSIG, EBDT, EBLC, FFTM, GDEF, GMAP, GPKG, GPOS, GSUB, JSTF, LTSH, MATH, META, OS/2, SING, SVG, TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS, TSIV, VDMX, VORG, avar, cmap, cvt, feat, fpgm, fvar, gasp, glyf, gvar, hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, name, post, prep, sbix, vhea and vmtx
 <!-- end table list -->
 </TT></BLOCKQUOTE>
 Other tables are dumped as hexadecimal data.

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -44,6 +44,7 @@ def _moduleFinderHint():
 	from . import T_S_I__5
 	from . import V_D_M_X_
 	from . import V_O_R_G_
+	from . import _a_v_a_r
 	from . import _c_m_a_p
 	from . import _c_v_t
 	from . import _f_e_a_t

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -1,0 +1,98 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools import ttLib
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.textTools import safeEval
+from fontTools.ttLib import TTLibError
+from . import DefaultTable
+import array
+import io
+import sys
+import struct
+import warnings
+
+
+# Apple's documentation of 'avar':
+# https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6avar.html
+
+AVAR_HEADER_FORMAT = """
+    > # big endian
+    version:    L
+    axisCount:  L
+"""
+
+
+class table__a_v_a_r(DefaultTable.DefaultTable):
+    dependencies = ["fvar"]
+
+    def __init__(self, tag=None):
+        DefaultTable.DefaultTable.__init__(self, tag)
+        self.segments = {}
+
+    def compile(self, ttFont):
+        fvarAxes = ttFont["fvar"].table.VariationAxis
+        axisTags = [axis.AxisTag for axis in fvarAxes]
+        header = {"version": 0x00010000, "axisCount": len(axisTags)}
+        result = [sstruct.pack(AVAR_HEADER_FORMAT, header)]
+        for axis in axisTags:
+            mappings = sorted(self.segments[axis].items())
+            result.append(struct.pack(">H", len(mappings)))
+            for key, value in mappings:
+                fixedKey = floatToFixed(key, 14)
+                fixedValue = floatToFixed(value, 14)
+                result.append(struct.pack(">hh", fixedKey, fixedValue))
+        return bytesjoin(result)
+
+    def decompile(self, data, ttFont):
+        fvarAxes = ttFont["fvar"].table.VariationAxis
+        axisTags = [axis.AxisTag for axis in fvarAxes]
+        header = {}
+        headerSize = sstruct.calcsize(AVAR_HEADER_FORMAT)
+        header = sstruct.unpack(AVAR_HEADER_FORMAT, data[0:headerSize])
+        if header["version"] != 0x00010000:
+            raise TTLibError("unsupported 'avar' version %04x" % header["version"])
+        pos = headerSize
+        for axis in axisTags:
+            segments = self.segments[axis] = {}
+            numPairs = struct.unpack(">H", data[pos:pos+2])[0]
+            pos = pos + 2
+            for _ in range(numPairs):
+                fromValue, toValue = struct.unpack(">hh", data[pos:pos+4])
+                segments[fixedToFloat(fromValue, 14)] = fixedToFloat(toValue, 14)
+                pos = pos + 4
+        self.fixupSegments_(warn=warnings.warn)
+
+    def toXML(self, writer, ttFont, progress=None):
+        axisTags = [axis.AxisTag for axis in ttFont["fvar"].table.VariationAxis]
+        for axis in axisTags:
+            writer.begintag("segment", axis=axis)
+            writer.newline()
+            for key, value in sorted(self.segments[axis].items()):
+                writer.simpletag("mapping", **{"from": key, "to": value})
+                writer.newline()
+            writer.endtag("segment")
+            writer.newline()
+
+    def fromXML(self, name, attrs, content, ttFont):
+        if name == "segment":
+            axis = attrs["axis"]
+            segment = self.segments[axis] = {}
+            for element in content:
+                if isinstance(element, tuple):
+                    elementName, elementAttrs, elementContent = element
+                    if elementName == "mapping":
+                        fromValue = safeEval(elementAttrs["from"])
+                        toValue = safeEval(elementAttrs["to"])
+                        if fromValue in segment:
+                            warnings.warn("duplicate entry for %s in axis '%s'" %
+                                          (fromValue, axis))
+                        segment[fromValue] = toValue
+            self.fixupSegments_(warn=warnings.warn)
+
+    def fixupSegments_(self, warn):
+        for axis, mappings in self.segments.items():
+            for k in [-1.0, 0.0, 1.0]:
+                if mappings.get(k) != k:
+                    warn("avar axis '%s' should map %s to %s" % (axis, k, k))
+                    mappings[k] = k

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r_test.py
@@ -1,0 +1,88 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.textTools import deHexStr
+from fontTools.misc.xmlWriter import XMLWriter
+from fontTools.ttLib import TTLibError
+from fontTools.ttLib.tables._a_v_a_r import table__a_v_a_r
+import collections
+import unittest
+
+
+TEST_DATA = deHexStr(
+    "00 01 00 00 00 00 00 02 "
+    "00 04 C0 00 C0 00 00 00 00 00 13 33 33 33 40 00 40 00 "
+    "00 03 C0 00 C0 00 00 00 00 00 40 00 40 00")
+
+
+class AxisVariationTableTest(unittest.TestCase):
+    def test_compile(self):
+        avar = table__a_v_a_r()
+        avar.segments["wdth"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
+        avar.segments["wght"] = {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
+        self.assertEqual(TEST_DATA, avar.compile(self.makeFont(["wdth", "wght"])))
+
+    def test_decompile(self):
+        avar = table__a_v_a_r()
+        avar.decompile(TEST_DATA, self.makeFont(["wdth", "wght"]))
+        self.assertEqual({
+            "wdth": {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0},
+            "wght": {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
+        }, avar.segments)
+
+    def test_decompile_unsupportedVersion(self):
+        avar = table__a_v_a_r()
+        font = self.makeFont(["wdth", "wght"])
+        self.assertRaises(TTLibError, avar.decompile, deHexStr("02 01 03 06 00 00 00 00"), font)
+
+    def test_toXML(self):
+        avar = table__a_v_a_r()
+        avar.segments["opsz"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
+        writer = XMLWriter(StringIO())
+        avar.toXML(writer, self.makeFont(["opsz"]))
+        self.assertEqual([
+            '<segment axis="opsz">',
+                '<mapping from="-1.0" to="-1.0"/>',
+                '<mapping from="0.0" to="0.0"/>',
+                '<mapping from="0.3" to="0.8"/>',
+                '<mapping from="1.0" to="1.0"/>',
+            '</segment>'
+        ], self.xml_lines(writer))
+
+    def test_fromXML(self):
+        avar = table__a_v_a_r()
+        avar.fromXML("segment", {"axis":"wdth"}, [
+                ("mapping", {"from": "-1.0", "to": "-1.0"}, []),
+                ("mapping", {"from": "0.0", "to": "0.0"}, []),
+                ("mapping", {"from": "0.7", "to": "0.2"}, []),
+                ("mapping", {"from": "1.0", "to": "1.0"}, [])
+                ], ttFont=None)
+        self.assertEqual({"wdth": {-1: -1, 0: 0, 0.7: 0.2, 1.0: 1.0}}, avar.segments)
+
+    def test_fixupSegments(self):
+        avar = table__a_v_a_r()
+        avar.segments = {"wdth": {0.3: 0.8, 1.0: 0.7}}
+        warnings = []
+        avar.fixupSegments_(lambda w: warnings.append(w))
+        self.assertEqual({"wdth": {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}}, avar.segments)
+        self.assertEqual([
+                "avar axis 'wdth' should map -1.0 to -1.0",
+                "avar axis 'wdth' should map 0.0 to 0.0",
+                "avar axis 'wdth' should map 1.0 to 1.0"
+        ], warnings)
+
+    @staticmethod
+    def makeFont(axisTags):
+        """['opsz', 'wdth'] --> ttFont"""
+        axes = [collections.namedtuple("A", "AxisTag")(axis) for axis in axisTags]
+        varaxis = collections.namedtuple("B", "VariationAxis")(axes)
+        fvar = collections.namedtuple("C", "table")(varaxis)
+        return {"fvar": fvar}
+
+    @staticmethod
+    def xml_lines(writer):
+        content = writer.file.getvalue().decode("utf-8")
+        return [line.strip() for line in content.splitlines()][1:]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When using TTX to inject a distorting ‘avar’ table into Skia.ttf:

    <segment axis="wdth">
      <mapping from="-1.0" to="-1.0"/>
      <mapping from="-0.1" to="-1.0"/>
      <mapping from="0" to="0"/>
      <mapping from="0.1" to="1.0"/>
      <mapping from="1.0" to="1.0"/>
    </segment>

MacOS X renders a range of widths as one would expect:

![avar-distorted](https://cloud.githubusercontent.com/assets/1527880/8263907/2e11abb4-16e0-11e5-8158-8a36bb6d9438.png)
