### PR TITLE
[ttx] don't create output file if action is 'ttList'

### DIFF
--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -314,7 +314,8 @@ def parseOptions(args):
 		else:
 			output = makeOutputFileName(input, options.outputDir, extension, options.overWrite)
 			# 'touch' output file to avoid race condition in choosing file names
-			open(output, 'a').close()
+			if action != ttList:
+				open(output, 'a').close()
 		jobs.append((action, input, output))
 	return jobs, options
 


### PR DESCRIPTION
after https://github.com/behdad/fonttools/pull/279, ttx was creating an empty file every time one listed the  table directory.