### PR TITLE
[E_B_D_T_] make 'bitmaps' directory in the same location as output TTX file

### DIFF
--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -338,15 +338,20 @@ def _readBitwiseImageData(bitmapObject, name, attrs, content, ttFont):
 	bitmapObject.setRows(dataRows, bitDepth=bitDepth, metrics=metrics, reverseBytes=True)
 
 def _writeExtFileImageData(strikeIndex, glyphName, bitmapObject, writer, ttFont):
-	folder = 'bitmaps/'
+	try:
+		folder = os.path.dirname(writer.file.name)
+	except AttributeError:
+		# fall back to current directory if output file's directory isn't found
+		folder = '.'
+	folder = os.path.join(folder, 'bitmaps')
 	filename = glyphName + bitmapObject.fileExtension
 	if not os.path.isdir(folder):
 		os.makedirs(folder)
-	folder += 'strike%d/' % strikeIndex
+	folder = os.path.join(folder, 'strike%d' % strikeIndex)
 	if not os.path.isdir(folder):
 		os.makedirs(folder)
 
-	fullPath = folder + filename
+	fullPath = os.path.join(folder, filename)
 	writer.simpletag('extfileimagedata', value=fullPath)
 	writer.newline()
 


### PR DESCRIPTION
Fixes https://github.com/behdad/fonttools/issues/295, by getting the `dirname()` of the output TTX file.
