### PR TITLE
Helper function to find a debug string for a name

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -90,6 +90,23 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 					return namerecord
 		return None # not found
 
+	def getDebugName(self, nameID):
+		englishName = someName = None
+		for name in self.names:
+			try:
+				unistr = name.toUnicode()
+			except UnicodeDecodeError:
+				unistr = None
+			if name.nameID == nameID and unistr:
+				someName = unistr
+				if (name.platformID, name.langID) in ((1, 0), (3, 0x409)):
+					englishName = unistr
+		if englishName:
+			return englishName
+		elif someName:
+			return someName
+		else:
+			return None
 
 class NameRecord(object):
 


### PR DESCRIPTION
Useful for generating XML comments when tables refer to name IDs.
For example, XML for a named instance in an ‘fvar’ table is easier
to read when it says <!-- Bold --> in addition to nameID="258".