### PR TITLE
[cffLib] Fix encoding of Notice and Copyright values in XML on Python 2

### DIFF
--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -673,7 +673,7 @@ class ASCIIConverter(SimpleConverter):
 	def write(self, parent, value):
 		return tobytes(value, encoding='ascii')
 	def xmlWrite(self, xmlWriter, name, value, progress):
-		xmlWriter.simpletag(name, value=tostr(value, encoding="ascii"))
+		xmlWriter.simpletag(name, value=tounicode(value, encoding="ascii"))
 		xmlWriter.newline()
 	def xmlRead(self, name, attrs, content, parent):
 		return tobytes(attrs["value"], encoding=("ascii"))
@@ -684,7 +684,7 @@ class Latin1Converter(SimpleConverter):
 	def write(self, parent, value):
 		return tobytes(value, encoding='latin1')
 	def xmlWrite(self, xmlWriter, name, value, progress):
-		xmlWriter.simpletag(name, value=tostr(value, encoding="latin1"))
+		xmlWriter.simpletag(name, value=tounicode(value, encoding="latin1"))
 		xmlWriter.newline()
 	def xmlRead(self, name, attrs, content, parent):
 		return tobytes(attrs["value"], encoding=("latin1"))

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -142,7 +142,9 @@ class XMLWriter(object):
 			return ""
 		data = ""
 		for attr, value in attributes:
-			data = data + ' %s="%s"' % (attr, escapeattr(str(value)))
+			if not isinstance(value, (bytes, unicode)):
+				value = str(value)
+			data = data + ' %s="%s"' % (attr, escapeattr(value))
 		return data
 
 


### PR DESCRIPTION
In `Notice` and `Copyright` values, Latin-1 characters such as '©' or 'ç' are replaced with U+FFFD on Python 2.7.9:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ttFont sfntVersion="OTTO" ttLibVersion="2.5">

  <CFF>
    <CFFFont name="SabonNextLTPro-Regular">
      <version value="001.001"/>
      <Notice value="Copyright � 2002 - 2010 Linotype GmbH, www.linotype.com. All rights reserved. This font software may not be reproduced, modified, disclosed or transferred without the express written approval of Linotype GmbH. Sabon is a trademark of Linotype Corp. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions in the name of Linotype Corp. or its licensee Linotype GmbH. This typeface is original artwork of Jean Fran�ois Porchez. The design may be protected in certain jurisdictions."/>
      <Copyright value="Copyright � 2002 - 2010 Linotype GmbH, www.linotype.com. All rights reserved. This font software may not be reproduced, modified, disclosed or transferred without the express written approval of Linotype GmbH. Sabon is a trademark of Linotype Corp. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions in the name of Linotype Corp. or its licensee Linotype GmbH. This typeface is original artwork of Jean Fran�ois Porchez. The design may be protected in certain jurisdictions."/>
```
I think it should be as below, like on Python 3.4.0:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ttFont sfntVersion="OTTO" ttLibVersion="2.5">

  <CFF>
    <CFFFont name="SabonNextLTPro-Regular">
      <version value="001.001"/>
      <Notice value="Copyright © 2002 - 2010 Linotype GmbH, www.linotype.com. All rights reserved. This font software may not be reproduced, modified, disclosed or transferred without the express written approval of Linotype GmbH. Sabon is a trademark of Linotype Corp. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions in the name of Linotype Corp. or its licensee Linotype GmbH. This typeface is original artwork of Jean François Porchez. The design may be protected in certain jurisdictions."/>
      <Copyright value="Copyright © 2002 - 2010 Linotype GmbH, www.linotype.com. All rights reserved. This font software may not be reproduced, modified, disclosed or transferred without the express written approval of Linotype GmbH. Sabon is a trademark of Linotype Corp. registered in the U.S. Patent and Trademark Office and may be registered in certain other jurisdictions in the name of Linotype Corp. or its licensee Linotype GmbH. This typeface is original artwork of Jean François Porchez. The design may be protected in certain jurisdictions."/>
```