### PR TITLE
Write a font to stdout when compiling with "-o -"

### DIFF
--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -246,6 +246,7 @@ def ttCompile(input, output, options):
 			output = sys.stdout
 			if sys.platform == "win32":
 				# set binary flag on python2.x (Windows)
+				import platform
 				runtime = platform.python_implementation()
 				if runtime == "PyPy":
 					# the msvcrt trick doesn't work in pypy, so I use fdopen

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -240,6 +240,9 @@ def ttCompile(input, output, options):
 		mtime = os.path.getmtime(input)
 		ttf['head'].modified = timestampSinceEpoch(mtime)
 
+	if output == "-":
+		output = sys.stdout
+
 	ttf.save(output)
 
 	if options.verbose:
@@ -311,6 +314,9 @@ def parseOptions(args):
 
 		if options.outputFile:
 			output = options.outputFile
+			if output == "-":
+				options.quiet = True
+				options.verbose = False
 		else:
 			output = makeOutputFileName(input, options.outputDir, extension, options.overWrite)
 			# 'touch' output file to avoid race condition in choosing file names


### PR DESCRIPTION
Write a font to stdout when compiling with `-o -`.
Dumping XML to stdout is already supported (365b0bfce17d0eae765a6f432928c5a075871027).