### PR TITLE
Xml reader utf8

### DIFF
--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -27,20 +27,20 @@ class XMLReader(object):
 		if self.progress:
 			import stat
 			self.progress.set(0, os.stat(self.fileName)[stat.ST_SIZE] // 100 or 1)
-		file = open(self.fileName, encoding='utf_8')
+		file = open(self.fileName, encoding='utf-8')
 		self._parseFile(file)
 		file.close()
 
 	def _parseFile(self, file):
 		from xml.parsers.expat import ParserCreate
-		parser = ParserCreate()
+		parser = ParserCreate('utf-8')
 		parser.StartElementHandler = self._startElementHandler
 		parser.EndElementHandler = self._endElementHandler
 		parser.CharacterDataHandler = self._characterDataHandler
 
 		pos = 0
 		while True:
-			chunk = file.read(BUFSIZE)
+			chunk = file.read(BUFSIZE).encode('utf-8')
 			if not chunk:
 				parser.Parse(chunk, 1)
 				break

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -3,6 +3,7 @@ from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
+from io import open
 import os
 
 
@@ -26,7 +27,7 @@ class XMLReader(object):
 		if self.progress:
 			import stat
 			self.progress.set(0, os.stat(self.fileName)[stat.ST_SIZE] // 100 or 1)
-		file = open(self.fileName)
+		file = open(self.fileName, encoding='utf_8')
 		self._parseFile(file)
 		file.close()
 


### PR DESCRIPTION
If no "encoding" argument is provided to Python 3 `open` built-in function, the default platform's encoding will be used when decoding bytes to unicode. On Windows, this is usually `cp1252`.
So, we need to explicitly open xml files for reading with UTF-8 encoding (the xmlWriter always writes UTF-8 by default).
We can use the `io.open` function, which is a backport of Python 3 default file interface, and has therefore an `encoding` argument which can be used to decode the file's bytes into unicode strings.
The input of expat's xml parser, in turn, should consist of bytes, so we encode unicode strings to UTF-8 before passing them to the parser.

This should fix the first issue reported here: https://github.com/behdad/fonttools/issues/323