### PR TITLE
[fixedTools] make sure fixedToFloat function returns float on both python 2 and 3

### DIFF
--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -26,7 +26,7 @@ def fixedToFloat(value, precisionBits):
 	hi = value + eps
 	# If the range of valid choices spans an integer, return the integer.
 	if int(lo) != int(hi):
-		return round(value)
+		return float(round(value))
 	fmt = "%.8f"
 	lo = fmt % lo
 	hi = fmt % hi

--- a/Lib/fontTools/misc/fixedTools_test.py
+++ b/Lib/fontTools/misc/fixedTools_test.py
@@ -33,6 +33,10 @@ class FixedToolsTest(unittest.TestCase):
         self.assertEqual(-16384, floatToFixed(-1, 14))
         self.assertEqual(0, floatToFixed(0, 14))
 
+    def test_fixedToFloat_return_float(self):
+        value = fixedToFloat(16384, 14)
+        self.assertIsInstance(value, float)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
on python 3, the `round(1.0)` returns `1` (integer), whereas on python 2 it returns `1.0` (float).