### PR TITLE
[xmlReader] open file for reading bytes (and revert two previous commits...)

### DIFF
--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -26,7 +26,7 @@ class XMLReader(object):
 		if self.progress:
 			import stat
 			self.progress.set(0, os.stat(self.fileName)[stat.ST_SIZE] // 100 or 1)
-		file = open(self.fileName)
+		file = open(self.fileName, 'rb')
 		self._parseFile(file)
 		file.close()
 

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -3,7 +3,6 @@ from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
-from io import open
 import os
 
 
@@ -27,7 +26,7 @@ class XMLReader(object):
 		if self.progress:
 			import stat
 			self.progress.set(0, os.stat(self.fileName)[stat.ST_SIZE] // 100 or 1)
-		file = open(self.fileName, encoding='utf_8')
+		file = open(self.fileName)
 		self._parseFile(file)
 		file.close()
 

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -27,20 +27,20 @@ class XMLReader(object):
 		if self.progress:
 			import stat
 			self.progress.set(0, os.stat(self.fileName)[stat.ST_SIZE] // 100 or 1)
-		file = open(self.fileName, encoding='utf-8')
+		file = open(self.fileName, encoding='utf_8')
 		self._parseFile(file)
 		file.close()
 
 	def _parseFile(self, file):
 		from xml.parsers.expat import ParserCreate
-		parser = ParserCreate('utf-8')
+		parser = ParserCreate()
 		parser.StartElementHandler = self._startElementHandler
 		parser.EndElementHandler = self._endElementHandler
 		parser.CharacterDataHandler = self._characterDataHandler
 
 		pos = 0
 		while True:
-			chunk = file.read(BUFSIZE).encode('utf-8')
+			chunk = file.read(BUFSIZE)
 			if not chunk:
 				parser.Parse(chunk, 1)
 				break

--- a/Lib/fontTools/misc/xmlReader_test.py
+++ b/Lib/fontTools/misc/xmlReader_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+import os
+import unittest
+from fontTools.ttLib import TTFont
+from .xmlReader import XMLReader
+import tempfile
+
+
+class TestXMLReader(unittest.TestCase):
+
+	def test_decode_utf8(self):
+
+		class DebugXMLReader(XMLReader):
+
+			def __init__(self, fileName, ttFont, progress=None, quiet=False):
+				super(DebugXMLReader, self).__init__(
+					fileName, ttFont, progress, quiet)
+				self.contents = []
+
+			def _endElementHandler(self, name):
+				if self.stackSize == 3:
+					name, attrs, content = self.root
+					self.contents.append(content)
+				super(DebugXMLReader, self)._endElementHandler(name)
+
+		expected = 'fôôbär'
+		data = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+  <name>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      %s
+    </namerecord>
+  </name>
+</ttFont>
+''' % expected
+
+		with tempfile.NamedTemporaryFile(delete=False) as tmp:
+			tmp.write(data.encode('utf-8'))
+		reader = DebugXMLReader(tmp.name, TTFont(), quiet=True)
+		reader.read()
+		os.remove(tmp.name)
+		content = strjoin(reader.contents[0]).strip() 
+		self.assertEqual(expected, content)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
In commit 6b4567f, I submitted a patch to fix a `UnicodeDecodeError` raised by xmlReader on Windows Python 3 (https://github.com/behdad/fonttools/issues/323). I had xmlReader open files (still in "text" mode) with UTF-8 encoding, to prevent Windows from implicitly opening files using the locale cp1252 encoding.

However, the expat XML parser seems to require bytestrings as input. I you feed unicode strings, these will be implicitly converted to bytes using 'ascii' encoding. So in commit fe76598, I ended up re-encoding to UTF-8 the unicode strings as read from the file, before passing them to the parser.

I think it would be simpler and cleaner if we just open the file as `rb`, so we read in bytes and feed those directly to the expat parser. The latter will take care of applying the correct encoding (i.e. UTF-8) as declared in the xml header.