### PR TITLE
[xmlWriter] escape carriage returns '\r' using XML character entity '&13#;'

### DIFF
--- a/Lib/fontTools/misc/xmlReader_test.py
+++ b/Lib/fontTools/misc/xmlReader_test.py
@@ -46,6 +46,36 @@ class TestXMLReader(unittest.TestCase):
 		content = strjoin(reader.contents[0]).strip() 
 		self.assertEqual(expected, content)
 
+	def test_normalise_newlines(self):
+
+		class DebugXMLReader(XMLReader):
+
+			def __init__(self, fileName, ttFont, progress=None, quiet=False):
+				super(DebugXMLReader, self).__init__(
+					fileName, ttFont, progress, quiet)
+				self.newlines = []
+
+			def _characterDataHandler(self, data):
+				self.newlines.extend([c for c in data if c in ('\r', '\n')])
+
+		# notice how when CR is escaped, it is not normalised by the XML parser
+		data = (
+			'<ttFont>\r'                                    #        \r -> \n
+			'  <test>\r\n'                                  #      \r\n -> \n 
+			'    a line of text\n'                          #              \n
+			'    escaped CR and unix newline &#13;\n'       #   &#13;\n -> \r\n
+			'    escaped CR and macintosh newline &#13;\r'  #   &#13;\r -> \r\n
+			'    escaped CR and windows newline &#13;\r\n'  # &#13;\r\n -> \r\n
+			'  </test>\n'                                   #              \n
+			'</ttFont>')
+		with tempfile.NamedTemporaryFile(delete=False) as tmp:
+			tmp.write(data.encode('utf-8'))
+		reader = DebugXMLReader(tmp.name, TTFont(), quiet=True)
+		reader.read()
+		os.remove(tmp.name)
+		expected = ['\n'] * 3 + ['\r', '\n'] * 3 + ['\n']
+		self.assertEqual(expected, reader.newlines)
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -153,6 +153,7 @@ def escape(data):
 	data = data.replace("&", "&amp;")
 	data = data.replace("<", "&lt;")
 	data = data.replace(">", "&gt;")
+	data = data.replace("\r", "&#13;")
 	return data
 
 def escapeattr(data):

--- a/Lib/fontTools/misc/xmlWriter_test.py
+++ b/Lib/fontTools/misc/xmlWriter_test.py
@@ -99,6 +99,13 @@ class TestXMLWriter(unittest.TestCase):
 		self.assertEqual(expected, writer.stringifyattrs(attr='0'))
 		self.assertEqual(expected, writer.stringifyattrs(attr=u'0'))
 
+	def test_carriage_return_escaped(self):
+		writer = XMLWriter(StringIO())
+		writer.write("two lines\r\nseparated by Windows line endings")
+		self.assertEqual(
+			HEADER + b'two lines&#13;\nseparated by Windows line endings',
+			writer.file.getvalue())
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
by explicitly escaping any carriage returns `\r` that occurr within XML element tags, we make sure that TTX can roundtrip name records containing Windows-style line endings (`\r\n`).
If we don't escape carriage returns, these will get automatically normalised into Unix-style line endings `\n` by the expat XML parser.

See https://github.com/behdad/fonttools/issues/318.