### PR TITLE
[py23] disambiguate bytes vs unicode in-memory streams

### DIFF
--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -38,7 +38,7 @@ class PSTokenError(Exception): pass
 class PSError(Exception): pass
 
 
-class PSTokenizer(StringIO):
+class PSTokenizer(BytesIO):
 
 	def getnexttoken(self,
 			# localize some stuff, for performance

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -90,10 +90,18 @@ except NameError:
 	def byteord(c):
 		return c if isinstance(c, int) else ord(c)
 
+
+# the 'io' module provides the same I/O interface on both 2 and 3.
+# here we define an alias of io.StringIO to disambiguate it eternally...
+from io import BytesIO
+from io import StringIO as UnicodeIO
 try:
+	# in python 2, by 'StringIO' we still mean a stream of *byte* strings
 	from StringIO import StringIO
 except ImportError:
-	from io import BytesIO as StringIO
+	# in Python 3, we mean instead a stream of *unicode* strings
+	StringIO = UnicodeIO
+
 
 def strjoin(iterable, joiner=''):
 	return tostr(joiner).join(iterable)

--- a/Lib/fontTools/misc/xmlWriter_test.py
+++ b/Lib/fontTools/misc/xmlWriter_test.py
@@ -10,50 +10,50 @@ HEADER = b'<?xml version="1.0" encoding="UTF-8"?>' + linesep
 class TestXMLWriter(unittest.TestCase):
 
 	def test_comment_escaped(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.comment("This&that are <comments>")
 		self.assertEqual(HEADER + b"<!-- This&amp;that are &lt;comments&gt; -->", writer.file.getvalue())
 
 	def test_comment_multiline(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.comment("Hello world\nHow are you?")
 		self.assertEqual(HEADER + b"<!-- Hello world" + linesep + b"     How are you? -->",
 				 writer.file.getvalue())
 
 	def test_encoding_default(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_utf8(self):
 		# https://github.com/behdad/fonttools/issues/246
-		writer = XMLWriter(StringIO(), encoding="utf8")
+		writer = XMLWriter(BytesIO(), encoding="utf8")
 		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_UTF_8(self):
 		# https://github.com/behdad/fonttools/issues/246
-		writer = XMLWriter(StringIO(), encoding="UTF-8")
+		writer = XMLWriter(BytesIO(), encoding="UTF-8")
 		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_UTF8(self):
 		# https://github.com/behdad/fonttools/issues/246
-		writer = XMLWriter(StringIO(), encoding="UTF8")
+		writer = XMLWriter(BytesIO(), encoding="UTF8")
 		self.assertEqual(b'<?xml version="1.0" encoding="UTF-8"?>' + linesep,
 				 writer.file.getvalue())
 
 	def test_encoding_other(self):
-		self.assertRaises(Exception, XMLWriter, StringIO(),
+		self.assertRaises(Exception, XMLWriter, BytesIO(),
 				  encoding="iso-8859-1")
 
 	def test_write(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.write("foo&bar")
 		self.assertEqual(HEADER + b"foo&amp;bar", writer.file.getvalue())
 
 	def test_indent_dedent(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.write("foo")
 		writer.newline()
 		writer.indent()
@@ -65,24 +65,24 @@ class TestXMLWriter(unittest.TestCase):
 				 writer.file.getvalue())
 
 	def test_writecdata(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.writecdata("foo&bar")
 		self.assertEqual(HEADER + b"<![CDATA[foo&bar]]>", writer.file.getvalue())
 
 	def test_simpletag(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.simpletag("tag", a="1", b="2")
 		self.assertEqual(HEADER + b'<tag a="1" b="2"/>', writer.file.getvalue())
 
 	def test_begintag_endtag(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.begintag("tag", attr="value")
 		writer.write("content")
 		writer.endtag("tag")
 		self.assertEqual(HEADER + b'<tag attr="value">content</tag>', writer.file.getvalue())
 
 	def test_dumphex(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.dumphex("Type is a beautiful group of letters, not a group of beautiful letters.")
 		self.assertEqual(HEADER + bytesjoin([
 		    "54797065 20697320 61206265 61757469",
@@ -92,7 +92,7 @@ class TestXMLWriter(unittest.TestCase):
 		    "65747465 72732e  ", ""], joiner=linesep), writer.file.getvalue())
 
 	def test_stringifyattrs(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		expected = ' attr="0"'
 		self.assertEqual(expected, writer.stringifyattrs(attr=0))
 		self.assertEqual(expected, writer.stringifyattrs(attr=b'0'))
@@ -100,7 +100,7 @@ class TestXMLWriter(unittest.TestCase):
 		self.assertEqual(expected, writer.stringifyattrs(attr=u'0'))
 
 	def test_carriage_return_escaped(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		writer.write("two lines\r\nseparated by Windows line endings")
 		self.assertEqual(
 			HEADER + b'two lines&#13;\nseparated by Windows line endings',

--- a/Lib/fontTools/pens/pointInsidePen_test.py
+++ b/Lib/fontTools/pens/pointInsidePen_test.py
@@ -73,7 +73,7 @@ class PointInsidePenTest(unittest.TestCase):
 
     @staticmethod
     def render(draw_function, even_odd):
-        result = StringIO()
+        result = BytesIO()
         for y in range(5):
             for x in range(10):
                 pen = PointInsidePen(None, (x + 0.5, y + 0.5), even_odd)

--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -169,7 +169,7 @@ class TTFont(object):
 			# assume "file" is a readable file object
 			closeStream = False
 		# read input file in memory and wrap a stream around it to allow overwriting
-		tmp = StringIO(file.read())
+		tmp = BytesIO(file.read())
 		if hasattr(file, 'name'):
 			# save reference to input file name
 			tmp.name = file.name

--- a/Lib/fontTools/ttLib/macUtils.py
+++ b/Lib/fontTools/ttLib/macUtils.py
@@ -64,7 +64,7 @@ class SFNTResourceReader(object):
 			res = Res.Get1NamedResource('sfnt', res_name_or_index)
 		else:
 			res = Res.Get1IndResource('sfnt', res_name_or_index)
-		self.file = StringIO(res.data)
+		self.file = BytesIO(res.data)
 		Res.CloseResFile(resref)
 		self.name = path
 

--- a/Lib/fontTools/ttLib/tables/C_F_F_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_.py
@@ -12,11 +12,11 @@ class table_C_F_F_(DefaultTable.DefaultTable):
 		self._gaveGlyphOrder = False
 
 	def decompile(self, data, otFont):
-		self.cff.decompile(StringIO(data), otFont)
+		self.cff.decompile(BytesIO(data), otFont)
 		assert len(self.cff) == 1, "can't deal with multi-font CFF tables."
 
 	def compile(self, otFont):
-		f = StringIO()
+		f = BytesIO()
 		self.cff.compile(f, otFont)
 		return f.getvalue()
 

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -165,11 +165,11 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 				doc = data[start:end]
 				if doc.startswith(b"\x1f\x8b"):
 					import gzip
-					stringIO = StringIO(doc)
-					with gzip.GzipFile(None, "r", fileobj=stringIO) as gunzipper:
+					bytesIO = BytesIO(doc)
+					with gzip.GzipFile(None, "r", fileobj=bytesIO) as gunzipper:
 						doc = gunzipper.read()
 					self.compressed = True
-					del stringIO
+					del bytesIO
 				doc = tostr(doc, "utf_8")
 				self.docList.append( [doc, entry.startGlyphID, entry.endGlyphID] )
 
@@ -195,13 +195,13 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 			docBytes = tobytes(doc, encoding="utf_8")
 			if getattr(self, "compressed", False) and not docBytes.startswith(b"\x1f\x8b"):
 				import gzip
-				stringIO = StringIO()
-				with gzip.GzipFile(None, "w", fileobj=stringIO) as gzipper:
+				bytesIO = BytesIO()
+				with gzip.GzipFile(None, "w", fileobj=bytesIO) as gzipper:
 					gzipper.write(docBytes)
-				gzipped = stringIO.getvalue()
+				gzipped = bytesIO.getvalue()
 				if len(gzipped) < len(docBytes):
 					docBytes = gzipped
-				del gzipped, stringIO
+				del gzipped, bytesIO
 			docLength = len(docBytes)
 			curOffset += docLength
 			entry = struct.pack(">HHLL", startGlyphID, endGlyphID, docOffset, docLength)

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r_test.py
@@ -38,7 +38,7 @@ class AxisVariationTableTest(unittest.TestCase):
     def test_toXML(self):
         avar = table__a_v_a_r()
         avar.segments["opsz"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
-        writer = XMLWriter(StringIO())
+        writer = XMLWriter(BytesIO())
         avar.toXML(writer, self.makeFont(["opsz"]))
         self.assertEqual([
             '<segment axis="opsz">',

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r_test.py
@@ -74,7 +74,7 @@ class FontVariationTableTest(unittest.TestCase):
 
     def test_toXML(self):
         font = MakeFont()
-        writer = XMLWriter(StringIO())
+        writer = XMLWriter(BytesIO())
         font["fvar"].toXML(writer, font)
         xml = writer.file.getvalue().decode("utf-8")
         self.assertEqual(2, xml.count("<Axis>"))
@@ -116,7 +116,7 @@ class AxisTest(unittest.TestCase):
         axis.decompile(FVAR_AXIS_DATA)
         AddName(font, "Optical Size").nameID = 256
         axis.nameID = 256
-        writer = XMLWriter(StringIO())
+        writer = XMLWriter(BytesIO())
         axis.toXML(writer, font)
         self.assertEqual([
             '',
@@ -164,7 +164,7 @@ class NamedInstanceTest(unittest.TestCase):
         inst = NamedInstance()
         inst.nameID = AddName(font, "Light Condensed").nameID
         inst.coordinates = {"wght": 0.7, "wdth": 0.5}
-        writer = XMLWriter(StringIO())
+        writer = XMLWriter(BytesIO())
         inst.toXML(writer, font)
         self.assertEqual([
             '',

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r_test.py
@@ -190,7 +190,7 @@ class GlyphVariationTest(unittest.TestCase):
 		self.assertFalse(gvar.hasImpact())
 
 	def test_toXML(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		axes = {"wdth":(0.3, 0.4, 0.5), "wght":(0.0, 1.0, 1.0), "opsz":(-0.7, -0.7, 0.0)}
 		g = GlyphVariation(axes, [(9,8), None, (7,6), (0,0), (-1,-2), None])
 		g.toXML(writer, ["wdth", "wght", "opsz"])
@@ -207,7 +207,7 @@ class GlyphVariationTest(unittest.TestCase):
 		], GlyphVariationTest.xml_lines(writer))
 
 	def test_toXML_allDeltasNone(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		axes = {"wght":(0.0, 1.0, 1.0)}
 		g = GlyphVariation(axes, [None] * 5)
 		g.toXML(writer, ["wght", "wdth"])

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
@@ -30,7 +30,7 @@ class Test_l_t_a_g(unittest.TestCase):
 		self.assertEqual(["sr-Latn", "fa"], table.tags)
 
 	def test_toXML(self):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		table = table__l_t_a_g()
 		table.decompile(self.DATA_, ttFont=None)
 		table.toXML(writer, ttFont=None)

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
@@ -35,7 +35,7 @@ class MetaTableTest(unittest.TestCase):
     def test_toXML(self):
         table = table__m_e_t_a()
         table.data["TEST"] = b"\xCA\xFE\xBE\xEF"
-        writer = XMLWriter(StringIO())
+        writer = XMLWriter(BytesIO())
         table.toXML(writer, {"meta": table})
         xml = writer.file.getvalue().decode("utf-8")
         self.assertEqual([

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
@@ -52,7 +52,7 @@ class NameRecordTest(unittest.TestCase):
 		self.assertRaises(UnicodeDecodeError, name.toUnicode)
 
 	def toXML(self, name):
-		writer = XMLWriter(StringIO())
+		writer = XMLWriter(BytesIO())
 		name.toXML(writer, ttFont=None)
 		xml = writer.file.getvalue().decode("utf_8").strip()
 		return xml.split(writer.newlinestr.decode("utf_8"))[1:]


### PR DESCRIPTION
This fixes issue #328, whereby an exception is raised when running `traceback.print_exc` function.

The error occurs because the `file` argument is expecting a stream of `str` objects: on Python 2, this must be a stream of *bytes*, whereas on Python 3 it must be a stream of *unicode* strings.

Currently we are using the name `StringIO` to mean an in-memory stream of bytes on both python versions. 

This patch redefines the import statements inside `py23` so that, on both 2 and 3:
- the name `BytesIO` will unambiguously mean a stream of bytes;
- the name `UnicodeIO` means a stream of unicodes.

Finally, the name `StringIO` is declined in a version-specific sense: that is, as a stream of **bytes** on Python 2 and a stream of **unicodes** on Python 3. 

So we give streams a similar treatment as the one reserved for strings themselves (cf. `tobytes`, `tostr` and `tounicode` functions).

Of course, I replaced all usages of `StringIO` in the codebase with `BytesIO` -- except where it means "a stream of 'str', whatever that means in the Python version I'm running".

I hope this makes sense.
