### PR TITLE
[_v_h_e_a] don't recalc vertical bounds if recalcBBoxes == False

### DIFF
--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -35,7 +35,8 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
 		sstruct.unpack(vheaFormat, data, self)
 
 	def compile(self, ttFont):
-		self.recalc(ttFont)
+		if ttFont.isLoaded('glyf') and ttFont.recalcBBoxes:
+			self.recalc(ttFont)
 		return sstruct.pack(vheaFormat, self)
 
 	def recalc(self, ttFont):


### PR DESCRIPTION
unlike with the `hhea` table, for the corresponding `vhea` table the `recalcBBoxes` attribute of TTFont was not checked, and the vertical bounds were always recalculated.

Fixes #336.