### PR TITLE
change behaviour of reorderTables: allow True, None and False

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -17,6 +17,7 @@ from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
 from fontTools.ttLib import getSearchRange
 import struct
+from collections import OrderedDict
 
 
 class SFNTReader(object):
@@ -68,11 +69,12 @@ class SFNTReader(object):
 		if self.sfntVersion not in ("\x00\x01\x00\x00", "OTTO", "true"):
 			from fontTools import ttLib
 			raise ttLib.TTLibError("Not a TrueType or OpenType font (bad sfntVersion)")
-		self.tables = {}
+		self.tables = OrderedDict()
 		for i in range(self.numTables):
 			entry = self.DirectoryEntry()
 			entry.fromFile(self.file)
-			self.tables[Tag(entry.tag)] = entry
+			tag = Tag(entry.tag)
+			self.tables[tag] = entry
 
 		# Load flavor data if any
 		if self.flavor == "woff":
@@ -143,7 +145,7 @@ class SFNTWriter(object):
 		self.file.seek(self.nextTableOffset)
 		# make sure we're actually where we want to be. (old cStringIO bug)
 		self.file.write(b'\0' * (self.nextTableOffset - self.file.tell()))
-		self.tables = {}
+		self.tables = OrderedDict()
 
 	def __setitem__(self, tag, data):
 		"""Write raw table data to disk."""


### PR DESCRIPTION
I believe the current behaviour of `reorderTables` argument in `TTFont.save` function is wrong, or at least is a bit misleading.
It's clear what `reorderTables=True` means: i.e. set the table order to the one recommended by the OpenType specification.
However, when one sets `reorderTables=False`, one may wish that the "original" input font's table order would be kept upon saving. However, that's not the case because the input font's table order as stored in the SFNTReader entries `offset` attribute is simply ignored. Actually, the final order is just random. It basically is whatever order fonttools finds more convenient when recompiling the tables: i.e. based on whether a table has been loaded, and whether it's compilation depends on some other table being compiled first.

OK, I know the table order is meaningless from a functional point of view. And of course, such an "original" table order would be even less meaningful if a font was loaded from XML, in which case there's no reader object to read the table offsets from.

But anyway, I would like to propose to slightly change the current behaviour of `reorderTables`, so that it accepts three instead of the current two values:

- `True`: the current default, reordering by OT spec recommended order.
- `None`: don't care about table order, use whatever order is faster and more convenient (this is equivalent to the current `False`). 
- `False`: try to keep the input font's table order if it was loaded from binary file, or else same as `None`.

For example, say I load a font and save it back to a new file with `reorderTables=False` without doing anything else in between. If the original sfnt directory was valid, and inter-table padding was correct, etc., I would expect the input and output fonts to be identical to each other.

```shell
>>> font = TTFont("font.ttf", recalcBBoxes=False, recalcTimestamp=False)
>>> font.save("font_new.ttf", reorderTables=False)
>>> exit()
$ diff font.ttf font_new.ttf
$ echo $?
0
```

WDYT?