### PR TITLE
[travis] compile Brotli using `build_ext --libraries=stdc++` on pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,13 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - g++ --version
 install:
-  - pip install -vr requirements.txt
+  # To compile Brotli for pypy3 we also need to link libstdc++.
+  # See: https://github.com/behdad/fonttools/issues/339
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy3 ]]; then
+      pip install --global-option build_ext --global-option --libraries=stdc++ -vr requirements.txt;
+    else
+      pip install -vr requirements.txt;
+    fi
   - make install
 script:
   - make check


### PR DESCRIPTION
I use pip `--global-option` to run distutils `build_ext` command with a custom `--libraries=stdc++` argument when compiling brotli for pypy3.
This should fix the issue with importing the brotli module in pypy3, which in turn makes it skip the woff2 tests: https://github.com/behdad/fonttools/issues/339
Finger crossed...