### PR TITLE
Support non-BMP characters for synthetic glyph names

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -20,6 +20,21 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 				return subtable
 		return None # not found
 
+	def buildReversed(self):
+		"""Returns a reverse cmap such as {'one':{0x31}, 'A':{0x41,0x391}}.
+
+		The values are sets of Unicode codepoints because
+		some fonts map different codepoints to the same glyph.
+		For example, U+0041 LATIN CAPITAL LETTER A and U+0391
+		GREEK CAPITAL LETTER ALPHA are sometimes the same glyph.
+		"""
+		result = {}
+		for subtable in self.tables:
+			if subtable.isUnicode():
+				for codepoint, name in subtable.cmap.items():
+					result.setdefault(name, set()).add(codepoint)
+		return result
+
 	def decompile(self, data, ttFont):
 		tableVersion, numSubTables = struct.unpack(">HH", data[:4])
 		self.tableVersion = int(tableVersion)

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p_test.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p_test.py
@@ -2,37 +2,37 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from fontTools.misc.py23 import *
 from fontTools import ttLib
 import unittest
-from ._c_m_a_p import CmapSubtable
+from ._c_m_a_p import CmapSubtable, table__c_m_a_p
 
 class CmapSubtableTest(unittest.TestCase):
 
-	def makeSubtable(self, platformID, platEncID, langID):
-		subtable = CmapSubtable(None)
+	def makeSubtable(self, cmapFormat, platformID, platEncID, langID):
+		subtable = CmapSubtable.newSubtable(cmapFormat)
 		subtable.platformID, subtable.platEncID, subtable.language = (platformID, platEncID, langID)
 		return subtable
 
 	def test_toUnicode_utf16be(self):
-		subtable = self.makeSubtable(0, 2, 7)
+		subtable = self.makeSubtable(4, 0, 2, 7)
 		self.assertEqual("utf_16_be", subtable.getEncoding())
 		self.assertEqual(True, subtable.isUnicode())
 
 	def test_toUnicode_macroman(self):
-		subtable = self.makeSubtable(1, 0, 7)  # MacRoman
+		subtable = self.makeSubtable(4, 1, 0, 7)  # MacRoman
 		self.assertEqual("mac_roman", subtable.getEncoding())
 		self.assertEqual(False, subtable.isUnicode())
 
 	def test_toUnicode_macromanian(self):
-		subtable = self.makeSubtable(1, 0, 37)  # Mac Romanian
+		subtable = self.makeSubtable(4, 1, 0, 37)  # Mac Romanian
 		self.assertNotEqual(None, subtable.getEncoding())
 		self.assertEqual(False, subtable.isUnicode())
 
 	def test_extended_mac_encodings(self):
-		subtable = self.makeSubtable(1, 1, 0) # Mac Japanese
+		subtable = self.makeSubtable(4, 1, 1, 0) # Mac Japanese
 		self.assertNotEqual(None, subtable.getEncoding())
 		self.assertEqual(False, subtable.isUnicode())
 
 	def test_extended_unknown(self):
-		subtable = self.makeSubtable(10, 11, 12)
+		subtable = self.makeSubtable(4, 10, 11, 12)
 		self.assertEqual(subtable.getEncoding(), None)
 		self.assertEqual(subtable.getEncoding("ascii"), "ascii")
 		self.assertEqual(subtable.getEncoding(default="xyz"), "xyz")
@@ -48,6 +48,16 @@ class CmapSubtableTest(unittest.TestCase):
 		font = ttLib.TTFont()
 		font.setGlyphOrder([])
 		subtable.decompile(b'\0' * 7 + b'\x10' + b'\0' * 8, font)
+
+	def test_buildReversed(self):
+		c4 = self.makeSubtable(4, 3, 1, 0)
+		c4.cmap = {0x0041:'A', 0x0391:'A'}
+		c12 = self.makeSubtable(12, 3, 10, 0)
+		c12.cmap = {0x10314: 'u10314'}
+		cmap = table__c_m_a_p()
+		cmap.tables = [c4, c12]
+		self.assertEqual(cmap.buildReversed(), {'A':{0x0041, 0x0391}, 'u10314':{0x10314}})
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -226,7 +226,14 @@ class WOFF2Writer(SFNTWriter):
 		"""
 		if self.sfntVersion == "OTTO":
 			return
-		for tag in ('maxp', 'head', 'loca', 'glyf'):
+
+		# make up glyph names required to decompile glyf table
+		self._decompileTable('maxp')
+		numGlyphs = self.ttFont['maxp'].numGlyphs
+		glyphOrder = ['.notdef'] + ["glyph%.5d" % i for i in range(1, numGlyphs)]
+		self.ttFont.setGlyphOrder(glyphOrder)
+
+		for tag in ('head', 'loca', 'glyf'):
 			self._decompileTable(tag)
 		self.ttFont['glyf'].padding = padding
 		for tag in ('glyf', 'loca'):

--- a/Lib/fontTools/ttLib/woff2_test.py
+++ b/Lib/fontTools/ttLib/woff2_test.py
@@ -611,9 +611,11 @@ class WOFF2GlyfTableTest(unittest.TestCase):
 		reader = WOFF2Reader(infile)
 		cls.transformedGlyfData = reader.tables['glyf'].loadData(
 			reader.transformBuffer)
+		cls.glyphOrder = ['.notdef'] + ["glyph%.5d" % i for i in range(1, font['maxp'].numGlyphs)]
 
 	def setUp(self):
 		self.font = font = ttLib.TTFont(recalcBBoxes=False, recalcTimestamp=False)
+		font.setGlyphOrder(self.glyphOrder)
 		font['head'] = ttLib.getTableClass('head')()
 		font['maxp'] = ttLib.getTableClass('maxp')()
 		font['loca'] = WOFF2LocaTable()


### PR DESCRIPTION
When a font supplies no glyph names in its 'post' table, fontTools
builds synthetic glyph names by reversing the 'cmap' table.
After this change, the library looks at all 'cmap' subtables for
Unicode, irrespective of format or platform. For example, glyph #4
in NotoSansOldItalic-Regular.ttf gets now named "u10300" instead of
"glyph00004".

Moved the code for building a reversed 'cmap' table into the cmap class,
for easier testing.