### PR TITLE
[feaLib] Use fontTools wrapper class for otTable's GSUB/GPOS tables

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.parser import Parser
+from fontTools.ttLib import getTableClass
 from fontTools.ttLib.tables import otTables
 import warnings
 
@@ -30,8 +31,9 @@ class Builder(object):
     def build(self):
         parsetree = Parser(self.featurefile_path).parse()
         parsetree.build(self)
-        self.gpos = self.font['GPOS'] = self.makeTable('GPOS')
-        self.gsub = self.font['GSUB'] = self.makeTable('GSUB')
+        for tag in ('GPOS', 'GSUB'):
+            fontTable = self.font[tag] = getTableClass(tag)()
+            fontTable.table = self.makeTable(tag)
 
     def get_lookup_(self, location, builder_class):
         if (self.cur_lookup_ and

--- a/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
@@ -2,73 +2,69 @@
 <ttFont>
 
   <GSUB>
-    <GSUB>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=1 -->
-        <ScriptRecord index="0">
-          <ScriptTag value="DFLT"/>
-          <Script>
-            <DefaultLangSys>
-              <ReqFeatureIndex value="65535"/>
-              <!-- FeatureCount=2 -->
-              <FeatureIndex index="0" value="0"/>
-              <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=0 -->
-          </Script>
-        </ScriptRecord>
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=2 -->
-        <FeatureRecord index="0">
-          <FeatureTag value="f1  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="1">
-          <FeatureTag value="f2  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=1 -->
-        <AlternateSubst index="0" Format="1">
-          <AlternateSet glyph="A">
-            <Alternate glyph="A.alt1"/>
-            <Alternate glyph="A.alt2"/>
-          </AlternateSet>
-          <AlternateSet glyph="B">
-            <Alternate glyph="B.alt1"/>
-            <Alternate glyph="B.alt2"/>
-            <Alternate glyph="B.alt3"/>
-          </AlternateSet>
-          <AlternateSet glyph="C">
-            <Alternate glyph="C.alt1"/>
-          </AlternateSet>
-        </AlternateSubst>
-      </LookupList>
-    </GSUB>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="f1  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="f2  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <AlternateSubst index="0" Format="1">
+        <AlternateSet glyph="A">
+          <Alternate glyph="A.alt1"/>
+          <Alternate glyph="A.alt2"/>
+        </AlternateSet>
+        <AlternateSet glyph="B">
+          <Alternate glyph="B.alt1"/>
+          <Alternate glyph="B.alt2"/>
+          <Alternate glyph="B.alt3"/>
+        </AlternateSet>
+        <AlternateSet glyph="C">
+          <Alternate glyph="C.alt1"/>
+        </AlternateSet>
+      </AlternateSubst>
+    </LookupList>
   </GSUB>
 
   <GPOS>
-    <GPOS>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=0 -->
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=0 -->
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=0 -->
-      </LookupList>
-    </GPOS>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
   </GPOS>
 
 </ttFont>

--- a/Lib/fontTools/feaLib/testdata/language_required.ttx
+++ b/Lib/fontTools/feaLib/testdata/language_required.ttx
@@ -2,135 +2,131 @@
 <ttFont>
 
   <GSUB>
-    <GSUB>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=1 -->
-        <ScriptRecord index="0">
-          <ScriptTag value="latn"/>
-          <Script>
-            <!-- LangSysCount=3 -->
-            <LangSysRecord index="0">
-              <LangSysTag value="DEU "/>
-              <LangSys>
-                <ReqFeatureIndex value="0"/>
-                <!-- FeatureCount=1 -->
-                <FeatureIndex index="0" value="1"/>
-              </LangSys>
-            </LangSysRecord>
-            <LangSysRecord index="1">
-              <LangSysTag value="FRA "/>
-              <LangSys>
-                <ReqFeatureIndex value="65535"/>
-                <!-- FeatureCount=2 -->
-                <FeatureIndex index="0" value="2"/>
-                <FeatureIndex index="1" value="1"/>
-              </LangSys>
-            </LangSysRecord>
-            <LangSysRecord index="2">
-              <LangSysTag value="ITA "/>
-              <LangSys>
-                <ReqFeatureIndex value="3"/>
-                <!-- FeatureCount=1 -->
-                <FeatureIndex index="0" value="1"/>
-              </LangSys>
-            </LangSysRecord>
-          </Script>
-        </ScriptRecord>
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=4 -->
-        <FeatureRecord index="0">
-          <FeatureTag value="hlig"/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="1">
-          <FeatureTag value="scmp"/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="3"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="2">
-          <FeatureTag value="hlig"/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="1"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="3">
-          <FeatureTag value="liga"/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="2"/>
-          </Feature>
-        </FeatureRecord>
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=4 -->
-        <LigatureSubst index="0" Format="1">
-          <LigatureSet glyph="D">
-            <Ligature components="D,E,U" glyph="D_E_U"/>
-          </LigatureSet>
-        </LigatureSubst>
-        <LigatureSubst index="1" Format="1">
-          <LigatureSet glyph="F">
-            <Ligature components="F,R,A" glyph="D_E_U"/>
-          </LigatureSet>
-        </LigatureSubst>
-        <LigatureSubst index="2" Format="1">
-          <LigatureSet glyph="I">
-            <Ligature components="I,T,A" glyph="I_T_A"/>
-          </LigatureSet>
-        </LigatureSubst>
-        <SingleSubst index="3">
-          <Substitution in="a" out="A.sc"/>
-          <Substitution in="b" out="B.sc"/>
-          <Substitution in="c" out="C.sc"/>
-          <Substitution in="d" out="D.sc"/>
-          <Substitution in="e" out="E.sc"/>
-          <Substitution in="f" out="F.sc"/>
-          <Substitution in="g" out="G.sc"/>
-          <Substitution in="h" out="H.sc"/>
-          <Substitution in="i" out="I.sc"/>
-          <Substitution in="j" out="J.sc"/>
-          <Substitution in="k" out="K.sc"/>
-          <Substitution in="l" out="L.sc"/>
-          <Substitution in="m" out="M.sc"/>
-          <Substitution in="n" out="N.sc"/>
-          <Substitution in="o" out="O.sc"/>
-          <Substitution in="p" out="P.sc"/>
-          <Substitution in="q" out="Q.sc"/>
-          <Substitution in="r" out="R.sc"/>
-          <Substitution in="s" out="S.sc"/>
-          <Substitution in="t" out="T.sc"/>
-          <Substitution in="u" out="U.sc"/>
-          <Substitution in="v" out="V.sc"/>
-          <Substitution in="w" out="W.sc"/>
-          <Substitution in="x" out="X.sc"/>
-          <Substitution in="y" out="Y.sc"/>
-          <Substitution in="z" out="Z.sc"/>
-        </SingleSubst>
-      </LookupList>
-    </GSUB>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <!-- LangSysCount=3 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="DEU "/>
+            <LangSys>
+              <ReqFeatureIndex value="0"/>
+              <!-- FeatureCount=1 -->
+              <FeatureIndex index="0" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="FRA "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="2"/>
+              <FeatureIndex index="1" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="2">
+            <LangSysTag value="ITA "/>
+            <LangSys>
+              <ReqFeatureIndex value="3"/>
+              <!-- FeatureCount=1 -->
+              <FeatureIndex index="0" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=4 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="hlig"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="scmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="hlig"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <LigatureSubst index="0" Format="1">
+        <LigatureSet glyph="D">
+          <Ligature components="D,E,U" glyph="D_E_U"/>
+        </LigatureSet>
+      </LigatureSubst>
+      <LigatureSubst index="1" Format="1">
+        <LigatureSet glyph="F">
+          <Ligature components="F,R,A" glyph="D_E_U"/>
+        </LigatureSet>
+      </LigatureSubst>
+      <LigatureSubst index="2" Format="1">
+        <LigatureSet glyph="I">
+          <Ligature components="I,T,A" glyph="I_T_A"/>
+        </LigatureSet>
+      </LigatureSubst>
+      <SingleSubst index="3">
+        <Substitution in="a" out="A.sc"/>
+        <Substitution in="b" out="B.sc"/>
+        <Substitution in="c" out="C.sc"/>
+        <Substitution in="d" out="D.sc"/>
+        <Substitution in="e" out="E.sc"/>
+        <Substitution in="f" out="F.sc"/>
+        <Substitution in="g" out="G.sc"/>
+        <Substitution in="h" out="H.sc"/>
+        <Substitution in="i" out="I.sc"/>
+        <Substitution in="j" out="J.sc"/>
+        <Substitution in="k" out="K.sc"/>
+        <Substitution in="l" out="L.sc"/>
+        <Substitution in="m" out="M.sc"/>
+        <Substitution in="n" out="N.sc"/>
+        <Substitution in="o" out="O.sc"/>
+        <Substitution in="p" out="P.sc"/>
+        <Substitution in="q" out="Q.sc"/>
+        <Substitution in="r" out="R.sc"/>
+        <Substitution in="s" out="S.sc"/>
+        <Substitution in="t" out="T.sc"/>
+        <Substitution in="u" out="U.sc"/>
+        <Substitution in="v" out="V.sc"/>
+        <Substitution in="w" out="W.sc"/>
+        <Substitution in="x" out="X.sc"/>
+        <Substitution in="y" out="Y.sc"/>
+        <Substitution in="z" out="Z.sc"/>
+      </SingleSubst>
+    </LookupList>
   </GSUB>
 
   <GPOS>
-    <GPOS>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=0 -->
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=0 -->
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=0 -->
-      </LookupList>
-    </GPOS>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
   </GPOS>
 
 </ttFont>

--- a/Lib/fontTools/feaLib/testdata/spec4h1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec4h1.ttx
@@ -2,150 +2,146 @@
 <ttFont>
 
   <GSUB>
-    <GSUB>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=3 -->
-        <ScriptRecord index="0">
-          <ScriptTag value="DFLT"/>
-          <Script>
-            <DefaultLangSys>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=2 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="DEU "/>
+            <LangSys>
               <ReqFeatureIndex value="65535"/>
               <!-- FeatureCount=2 -->
               <FeatureIndex index="0" value="0"/>
               <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=0 -->
-          </Script>
-        </ScriptRecord>
-        <ScriptRecord index="1">
-          <ScriptTag value="cyrl"/>
-          <Script>
-            <DefaultLangSys>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="TRK "/>
+            <LangSys>
               <ReqFeatureIndex value="65535"/>
               <!-- FeatureCount=2 -->
               <FeatureIndex index="0" value="0"/>
               <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=0 -->
-          </Script>
-        </ScriptRecord>
-        <ScriptRecord index="2">
-          <ScriptTag value="latn"/>
-          <Script>
-            <DefaultLangSys>
-              <ReqFeatureIndex value="65535"/>
-              <!-- FeatureCount=2 -->
-              <FeatureIndex index="0" value="0"/>
-              <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=2 -->
-            <LangSysRecord index="0">
-              <LangSysTag value="DEU "/>
-              <LangSys>
-                <ReqFeatureIndex value="65535"/>
-                <!-- FeatureCount=2 -->
-                <FeatureIndex index="0" value="0"/>
-                <FeatureIndex index="1" value="1"/>
-              </LangSys>
-            </LangSysRecord>
-            <LangSysRecord index="1">
-              <LangSysTag value="TRK "/>
-              <LangSys>
-                <ReqFeatureIndex value="65535"/>
-                <!-- FeatureCount=2 -->
-                <FeatureIndex index="0" value="0"/>
-                <FeatureIndex index="1" value="1"/>
-              </LangSys>
-            </LangSysRecord>
-          </Script>
-        </ScriptRecord>
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=2 -->
-        <FeatureRecord index="0">
-          <FeatureTag value="liga"/>
-          <Feature>
-            <!-- LookupCount=3 -->
-            <LookupListIndex index="0" value="1"/>
-            <LookupListIndex index="1" value="2"/>
-            <LookupListIndex index="2" value="3"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="1">
-          <FeatureTag value="smcp"/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=4 -->
-        <SingleSubst index="0">
-          <Substitution in="a" out="A.sc"/>
-          <Substitution in="b" out="B.sc"/>
-          <Substitution in="c" out="C.sc"/>
-          <Substitution in="d" out="D.sc"/>
-          <Substitution in="e" out="E.sc"/>
-          <Substitution in="f" out="F.sc"/>
-          <Substitution in="g" out="G.sc"/>
-          <Substitution in="h" out="H.sc"/>
-          <Substitution in="i" out="I.sc"/>
-          <Substitution in="j" out="J.sc"/>
-          <Substitution in="k" out="K.sc"/>
-          <Substitution in="l" out="L.sc"/>
-          <Substitution in="m" out="M.sc"/>
-          <Substitution in="n" out="N.sc"/>
-          <Substitution in="o" out="O.sc"/>
-          <Substitution in="p" out="P.sc"/>
-          <Substitution in="q" out="Q.sc"/>
-          <Substitution in="r" out="R.sc"/>
-          <Substitution in="s" out="S.sc"/>
-          <Substitution in="t" out="T.sc"/>
-          <Substitution in="u" out="U.sc"/>
-          <Substitution in="v" out="V.sc"/>
-          <Substitution in="w" out="W.sc"/>
-          <Substitution in="x" out="X.sc"/>
-          <Substitution in="y" out="Y.sc"/>
-          <Substitution in="z" out="Z.sc"/>
-        </SingleSubst>
-        <LigatureSubst index="1" Format="1">
-          <LigatureSet glyph="f">
-            <Ligature components="f,f" glyph="f_f"/>
-            <Ligature components="f,i" glyph="f_i"/>
-            <Ligature components="f,l" glyph="f_l"/>
-          </LigatureSet>
-        </LigatureSubst>
-        <LigatureSubst index="2" Format="1">
-          <LigatureSet glyph="c">
-            <Ligature components="c,s" glyph="c_s"/>
-            <Ligature components="c,t" glyph="c_t"/>
-          </LigatureSet>
-        </LigatureSubst>
-        <LigatureSubst index="3" Format="1">
-          <LigatureSet glyph="c">
-            <Ligature components="c,h" glyph="c_h"/>
-            <Ligature components="c,k" glyph="c_k"/>
-          </LigatureSet>
-        </LigatureSubst>
-      </LookupList>
-    </GSUB>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="1"/>
+          <LookupListIndex index="1" value="2"/>
+          <LookupListIndex index="2" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="smcp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <SingleSubst index="0">
+        <Substitution in="a" out="A.sc"/>
+        <Substitution in="b" out="B.sc"/>
+        <Substitution in="c" out="C.sc"/>
+        <Substitution in="d" out="D.sc"/>
+        <Substitution in="e" out="E.sc"/>
+        <Substitution in="f" out="F.sc"/>
+        <Substitution in="g" out="G.sc"/>
+        <Substitution in="h" out="H.sc"/>
+        <Substitution in="i" out="I.sc"/>
+        <Substitution in="j" out="J.sc"/>
+        <Substitution in="k" out="K.sc"/>
+        <Substitution in="l" out="L.sc"/>
+        <Substitution in="m" out="M.sc"/>
+        <Substitution in="n" out="N.sc"/>
+        <Substitution in="o" out="O.sc"/>
+        <Substitution in="p" out="P.sc"/>
+        <Substitution in="q" out="Q.sc"/>
+        <Substitution in="r" out="R.sc"/>
+        <Substitution in="s" out="S.sc"/>
+        <Substitution in="t" out="T.sc"/>
+        <Substitution in="u" out="U.sc"/>
+        <Substitution in="v" out="V.sc"/>
+        <Substitution in="w" out="W.sc"/>
+        <Substitution in="x" out="X.sc"/>
+        <Substitution in="y" out="Y.sc"/>
+        <Substitution in="z" out="Z.sc"/>
+      </SingleSubst>
+      <LigatureSubst index="1" Format="1">
+        <LigatureSet glyph="f">
+          <Ligature components="f,f" glyph="f_f"/>
+          <Ligature components="f,i" glyph="f_i"/>
+          <Ligature components="f,l" glyph="f_l"/>
+        </LigatureSet>
+      </LigatureSubst>
+      <LigatureSubst index="2" Format="1">
+        <LigatureSet glyph="c">
+          <Ligature components="c,s" glyph="c_s"/>
+          <Ligature components="c,t" glyph="c_t"/>
+        </LigatureSet>
+      </LigatureSubst>
+      <LigatureSubst index="3" Format="1">
+        <LigatureSet glyph="c">
+          <Ligature components="c,h" glyph="c_h"/>
+          <Ligature components="c,k" glyph="c_k"/>
+        </LigatureSet>
+      </LigatureSubst>
+    </LookupList>
   </GSUB>
 
   <GPOS>
-    <GPOS>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=0 -->
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=0 -->
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=0 -->
-      </LookupList>
-    </GPOS>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
   </GPOS>
 
 </ttFont>

--- a/Lib/fontTools/feaLib/testdata/spec5d1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d1.ttx
@@ -2,73 +2,69 @@
 <ttFont>
 
   <GSUB>
-    <GSUB>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=1 -->
-        <ScriptRecord index="0">
-          <ScriptTag value="DFLT"/>
-          <Script>
-            <DefaultLangSys>
-              <ReqFeatureIndex value="65535"/>
-              <!-- FeatureCount=2 -->
-              <FeatureIndex index="0" value="0"/>
-              <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=0 -->
-          </Script>
-        </ScriptRecord>
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=2 -->
-        <FeatureRecord index="0">
-          <FeatureTag value="F1  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="1">
-          <FeatureTag value="F2  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=1 -->
-        <LigatureSubst index="0" Format="1">
-          <LigatureSet glyph="one">
-            <Ligature components="one,fraction,two" glyph="onehalf"/>
-            <Ligature components="one,fraction,two.oldstyle" glyph="onehalf"/>
-            <Ligature components="one,slash,two" glyph="onehalf"/>
-            <Ligature components="one,slash,two.oldstyle" glyph="onehalf"/>
-          </LigatureSet>
-          <LigatureSet glyph="one.oldstyle">
-            <Ligature components="one.oldstyle,fraction,two" glyph="onehalf"/>
-            <Ligature components="one.oldstyle,fraction,two.oldstyle" glyph="onehalf"/>
-            <Ligature components="one.oldstyle,slash,two" glyph="onehalf"/>
-            <Ligature components="one.oldstyle,slash,two.oldstyle" glyph="onehalf"/>
-          </LigatureSet>
-        </LigatureSubst>
-      </LookupList>
-    </GSUB>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="F1  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="F2  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <LigatureSubst index="0" Format="1">
+        <LigatureSet glyph="one">
+          <Ligature components="one,fraction,two" glyph="onehalf"/>
+          <Ligature components="one,fraction,two.oldstyle" glyph="onehalf"/>
+          <Ligature components="one,slash,two" glyph="onehalf"/>
+          <Ligature components="one,slash,two.oldstyle" glyph="onehalf"/>
+        </LigatureSet>
+        <LigatureSet glyph="one.oldstyle">
+          <Ligature components="one.oldstyle,fraction,two" glyph="onehalf"/>
+          <Ligature components="one.oldstyle,fraction,two.oldstyle" glyph="onehalf"/>
+          <Ligature components="one.oldstyle,slash,two" glyph="onehalf"/>
+          <Ligature components="one.oldstyle,slash,two.oldstyle" glyph="onehalf"/>
+        </LigatureSet>
+      </LigatureSubst>
+    </LookupList>
   </GSUB>
 
   <GPOS>
-    <GPOS>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=0 -->
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=0 -->
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=0 -->
-      </LookupList>
-    </GPOS>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
   </GPOS>
 
 </ttFont>

--- a/Lib/fontTools/feaLib/testdata/spec5d2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d2.ttx
@@ -2,69 +2,65 @@
 <ttFont>
 
   <GSUB>
-    <GSUB>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=1 -->
-        <ScriptRecord index="0">
-          <ScriptTag value="DFLT"/>
-          <Script>
-            <DefaultLangSys>
-              <ReqFeatureIndex value="65535"/>
-              <!-- FeatureCount=2 -->
-              <FeatureIndex index="0" value="0"/>
-              <FeatureIndex index="1" value="1"/>
-            </DefaultLangSys>
-            <!-- LangSysCount=0 -->
-          </Script>
-        </ScriptRecord>
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=2 -->
-        <FeatureRecord index="0">
-          <FeatureTag value="F1  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-        <FeatureRecord index="1">
-          <FeatureTag value="F2  "/>
-          <Feature>
-            <!-- LookupCount=1 -->
-            <LookupListIndex index="0" value="0"/>
-          </Feature>
-        </FeatureRecord>
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=1 -->
-        <LigatureSubst index="0" Format="1">
-          <LigatureSet glyph="f">
-            <Ligature components="f,f,i" glyph="f_f_i"/>
-            <Ligature components="f,f" glyph="f_f"/>
-            <Ligature components="f,i" glyph="f_i"/>
-          </LigatureSet>
-          <LigatureSet glyph="o">
-            <Ligature components="o,f,f,i" glyph="o_f_f_i"/>
-          </LigatureSet>
-        </LigatureSubst>
-      </LookupList>
-    </GSUB>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="F1  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="F2  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <LigatureSubst index="0" Format="1">
+        <LigatureSet glyph="f">
+          <Ligature components="f,f,i" glyph="f_f_i"/>
+          <Ligature components="f,f" glyph="f_f"/>
+          <Ligature components="f,i" glyph="f_i"/>
+        </LigatureSet>
+        <LigatureSet glyph="o">
+          <Ligature components="o,f,f,i" glyph="o_f_f_i"/>
+        </LigatureSet>
+      </LigatureSubst>
+    </LookupList>
   </GSUB>
 
   <GPOS>
-    <GPOS>
-      <Version value="1.0"/>
-      <ScriptList>
-        <!-- ScriptCount=0 -->
-      </ScriptList>
-      <FeatureList>
-        <!-- FeatureCount=0 -->
-      </FeatureList>
-      <LookupList>
-        <!-- LookupCount=0 -->
-      </LookupList>
-    </GPOS>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
   </GPOS>
 
 </ttFont>


### PR DESCRIPTION
Resolves https://github.com/brawer/fonttools/commit/df740092d990e441550bf33fcd8bd15f5ae3dbc9#commitcomment-13138084