### PR TITLE
[feaLib] make LookupList.Lookup into a list of Lookup objects, not subtables

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -299,9 +299,15 @@ class AlternateSubstBuilder(LookupBuilder):
                 self.alternates == other.alternates)
 
     def build(self):
-        lookup = otTables.AlternateSubst()
-        lookup.Format = 1
-        lookup.alternates = self.alternates
+        lookup = otTables.Lookup()
+        lookup.SubTable = []
+        st = otTables.AlternateSubst()
+        st.Format = 1
+        st.alternates = self.alternates
+        lookup.SubTable.append(st)
+        lookup.LookupFlag = self.lookup_flag
+        lookup.LookupType = self.lookup_type
+        lookup.SubTableCount = len(lookup.SubTable)
         return lookup
 
 
@@ -329,14 +335,20 @@ class LigatureSubstBuilder(LookupBuilder):
         return (-len(components), components)
 
     def build(self):
-        lookup = otTables.LigatureSubst()
-        lookup.Format = 1
-        lookup.ligatures = {}
+        lookup = otTables.Lookup()
+        lookup.SubTable = []
+        st = otTables.LigatureSubst()
+        st.Format = 1
+        st.ligatures = {}
         for components in sorted(self.ligatures.keys(), key=self.make_key):
             lig = otTables.Ligature()
             lig.Component = components
             lig.LigGlyph = self.ligatures[components]
-            lookup.ligatures.setdefault(components[0], []).append(lig)
+            st.ligatures.setdefault(components[0], []).append(lig)
+        lookup.SubTable.append(st)
+        lookup.LookupFlag = self.lookup_flag
+        lookup.LookupType = self.lookup_type
+        lookup.SubTableCount = len(lookup.SubTable)
         return lookup
 
 
@@ -350,6 +362,12 @@ class SingleSubstBuilder(LookupBuilder):
                 self.mapping == other.mapping)
 
     def build(self):
-        lookup = otTables.SingleSubst()
-        lookup.mapping = self.mapping
+        lookup = otTables.Lookup()
+        lookup.SubTable = []
+        st = otTables.SingleSubst()
+        st.mapping = self.mapping
+        lookup.SubTable.append(st)
+        lookup.LookupFlag = self.lookup_flag
+        lookup.LookupType = self.lookup_type
+        lookup.SubTableCount = len(lookup.SubTable)
         return lookup

--- a/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
@@ -37,20 +37,25 @@
     </FeatureList>
     <LookupList>
       <!-- LookupCount=1 -->
-      <AlternateSubst index="0" Format="1">
-        <AlternateSet glyph="A">
-          <Alternate glyph="A.alt1"/>
-          <Alternate glyph="A.alt2"/>
-        </AlternateSet>
-        <AlternateSet glyph="B">
-          <Alternate glyph="B.alt1"/>
-          <Alternate glyph="B.alt2"/>
-          <Alternate glyph="B.alt3"/>
-        </AlternateSet>
-        <AlternateSet glyph="C">
-          <Alternate glyph="C.alt1"/>
-        </AlternateSet>
-      </AlternateSubst>
+      <Lookup index="0">
+        <!-- LookupType=3 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <AlternateSubst index="0" Format="1">
+          <AlternateSet glyph="A">
+            <Alternate glyph="A.alt1"/>
+            <Alternate glyph="A.alt2"/>
+          </AlternateSet>
+          <AlternateSet glyph="B">
+            <Alternate glyph="B.alt1"/>
+            <Alternate glyph="B.alt2"/>
+            <Alternate glyph="B.alt3"/>
+          </AlternateSet>
+          <AlternateSet glyph="C">
+            <Alternate glyph="C.alt1"/>
+          </AlternateSet>
+        </AlternateSubst>
+      </Lookup>
     </LookupList>
   </GSUB>
 

--- a/Lib/fontTools/feaLib/testdata/language_required.ttx
+++ b/Lib/fontTools/feaLib/testdata/language_required.ttx
@@ -70,49 +70,69 @@
     </FeatureList>
     <LookupList>
       <!-- LookupCount=4 -->
-      <LigatureSubst index="0" Format="1">
-        <LigatureSet glyph="D">
-          <Ligature components="D,E,U" glyph="D_E_U"/>
-        </LigatureSet>
-      </LigatureSubst>
-      <LigatureSubst index="1" Format="1">
-        <LigatureSet glyph="F">
-          <Ligature components="F,R,A" glyph="D_E_U"/>
-        </LigatureSet>
-      </LigatureSubst>
-      <LigatureSubst index="2" Format="1">
-        <LigatureSet glyph="I">
-          <Ligature components="I,T,A" glyph="I_T_A"/>
-        </LigatureSet>
-      </LigatureSubst>
-      <SingleSubst index="3">
-        <Substitution in="a" out="A.sc"/>
-        <Substitution in="b" out="B.sc"/>
-        <Substitution in="c" out="C.sc"/>
-        <Substitution in="d" out="D.sc"/>
-        <Substitution in="e" out="E.sc"/>
-        <Substitution in="f" out="F.sc"/>
-        <Substitution in="g" out="G.sc"/>
-        <Substitution in="h" out="H.sc"/>
-        <Substitution in="i" out="I.sc"/>
-        <Substitution in="j" out="J.sc"/>
-        <Substitution in="k" out="K.sc"/>
-        <Substitution in="l" out="L.sc"/>
-        <Substitution in="m" out="M.sc"/>
-        <Substitution in="n" out="N.sc"/>
-        <Substitution in="o" out="O.sc"/>
-        <Substitution in="p" out="P.sc"/>
-        <Substitution in="q" out="Q.sc"/>
-        <Substitution in="r" out="R.sc"/>
-        <Substitution in="s" out="S.sc"/>
-        <Substitution in="t" out="T.sc"/>
-        <Substitution in="u" out="U.sc"/>
-        <Substitution in="v" out="V.sc"/>
-        <Substitution in="w" out="W.sc"/>
-        <Substitution in="x" out="X.sc"/>
-        <Substitution in="y" out="Y.sc"/>
-        <Substitution in="z" out="Z.sc"/>
-      </SingleSubst>
+      <Lookup index="0">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="D">
+            <Ligature components="D,E,U" glyph="D_E_U"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="1">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="F">
+            <Ligature components="F,R,A" glyph="D_E_U"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="I">
+            <Ligature components="I,T,A" glyph="I_T_A"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="3">
+        <!-- LookupType=1 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="A.sc"/>
+          <Substitution in="b" out="B.sc"/>
+          <Substitution in="c" out="C.sc"/>
+          <Substitution in="d" out="D.sc"/>
+          <Substitution in="e" out="E.sc"/>
+          <Substitution in="f" out="F.sc"/>
+          <Substitution in="g" out="G.sc"/>
+          <Substitution in="h" out="H.sc"/>
+          <Substitution in="i" out="I.sc"/>
+          <Substitution in="j" out="J.sc"/>
+          <Substitution in="k" out="K.sc"/>
+          <Substitution in="l" out="L.sc"/>
+          <Substitution in="m" out="M.sc"/>
+          <Substitution in="n" out="N.sc"/>
+          <Substitution in="o" out="O.sc"/>
+          <Substitution in="p" out="P.sc"/>
+          <Substitution in="q" out="Q.sc"/>
+          <Substitution in="r" out="R.sc"/>
+          <Substitution in="s" out="S.sc"/>
+          <Substitution in="t" out="T.sc"/>
+          <Substitution in="u" out="U.sc"/>
+          <Substitution in="v" out="V.sc"/>
+          <Substitution in="w" out="W.sc"/>
+          <Substitution in="x" out="X.sc"/>
+          <Substitution in="y" out="Y.sc"/>
+          <Substitution in="z" out="Z.sc"/>
+        </SingleSubst>
+      </Lookup>
     </LookupList>
   </GSUB>
 

--- a/Lib/fontTools/feaLib/testdata/spec4h1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec4h1.ttx
@@ -81,53 +81,73 @@
     </FeatureList>
     <LookupList>
       <!-- LookupCount=4 -->
-      <SingleSubst index="0">
-        <Substitution in="a" out="A.sc"/>
-        <Substitution in="b" out="B.sc"/>
-        <Substitution in="c" out="C.sc"/>
-        <Substitution in="d" out="D.sc"/>
-        <Substitution in="e" out="E.sc"/>
-        <Substitution in="f" out="F.sc"/>
-        <Substitution in="g" out="G.sc"/>
-        <Substitution in="h" out="H.sc"/>
-        <Substitution in="i" out="I.sc"/>
-        <Substitution in="j" out="J.sc"/>
-        <Substitution in="k" out="K.sc"/>
-        <Substitution in="l" out="L.sc"/>
-        <Substitution in="m" out="M.sc"/>
-        <Substitution in="n" out="N.sc"/>
-        <Substitution in="o" out="O.sc"/>
-        <Substitution in="p" out="P.sc"/>
-        <Substitution in="q" out="Q.sc"/>
-        <Substitution in="r" out="R.sc"/>
-        <Substitution in="s" out="S.sc"/>
-        <Substitution in="t" out="T.sc"/>
-        <Substitution in="u" out="U.sc"/>
-        <Substitution in="v" out="V.sc"/>
-        <Substitution in="w" out="W.sc"/>
-        <Substitution in="x" out="X.sc"/>
-        <Substitution in="y" out="Y.sc"/>
-        <Substitution in="z" out="Z.sc"/>
-      </SingleSubst>
-      <LigatureSubst index="1" Format="1">
-        <LigatureSet glyph="f">
-          <Ligature components="f,f" glyph="f_f"/>
-          <Ligature components="f,i" glyph="f_i"/>
-          <Ligature components="f,l" glyph="f_l"/>
-        </LigatureSet>
-      </LigatureSubst>
-      <LigatureSubst index="2" Format="1">
-        <LigatureSet glyph="c">
-          <Ligature components="c,s" glyph="c_s"/>
-          <Ligature components="c,t" glyph="c_t"/>
-        </LigatureSet>
-      </LigatureSubst>
-      <LigatureSubst index="3" Format="1">
-        <LigatureSet glyph="c">
-          <Ligature components="c,h" glyph="c_h"/>
-          <Ligature components="c,k" glyph="c_k"/>
-        </LigatureSet>
-      </LigatureSubst>
+      <Lookup index="0">
+        <!-- LookupType=1 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="A.sc"/>
+          <Substitution in="b" out="B.sc"/>
+          <Substitution in="c" out="C.sc"/>
+          <Substitution in="d" out="D.sc"/>
+          <Substitution in="e" out="E.sc"/>
+          <Substitution in="f" out="F.sc"/>
+          <Substitution in="g" out="G.sc"/>
+          <Substitution in="h" out="H.sc"/>
+          <Substitution in="i" out="I.sc"/>
+          <Substitution in="j" out="J.sc"/>
+          <Substitution in="k" out="K.sc"/>
+          <Substitution in="l" out="L.sc"/>
+          <Substitution in="m" out="M.sc"/>
+          <Substitution in="n" out="N.sc"/>
+          <Substitution in="o" out="O.sc"/>
+          <Substitution in="p" out="P.sc"/>
+          <Substitution in="q" out="Q.sc"/>
+          <Substitution in="r" out="R.sc"/>
+          <Substitution in="s" out="S.sc"/>
+          <Substitution in="t" out="T.sc"/>
+          <Substitution in="u" out="U.sc"/>
+          <Substitution in="v" out="V.sc"/>
+          <Substitution in="w" out="W.sc"/>
+          <Substitution in="x" out="X.sc"/>
+          <Substitution in="y" out="Y.sc"/>
+          <Substitution in="z" out="Z.sc"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="f">
+            <Ligature components="f,f" glyph="f_f"/>
+            <Ligature components="f,i" glyph="f_i"/>
+            <Ligature components="f,l" glyph="f_l"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="c">
+            <Ligature components="c,s" glyph="c_s"/>
+            <Ligature components="c,t" glyph="c_t"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="3">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="c">
+            <Ligature components="c,h" glyph="c_h"/>
+            <Ligature components="c,k" glyph="c_k"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
     </LookupList>
   </GSUB>
 

--- a/Lib/fontTools/feaLib/testdata/spec5d1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d1.ttx
@@ -37,20 +37,25 @@
     </FeatureList>
     <LookupList>
       <!-- LookupCount=1 -->
-      <LigatureSubst index="0" Format="1">
-        <LigatureSet glyph="one">
-          <Ligature components="one,fraction,two" glyph="onehalf"/>
-          <Ligature components="one,fraction,two.oldstyle" glyph="onehalf"/>
-          <Ligature components="one,slash,two" glyph="onehalf"/>
-          <Ligature components="one,slash,two.oldstyle" glyph="onehalf"/>
-        </LigatureSet>
-        <LigatureSet glyph="one.oldstyle">
-          <Ligature components="one.oldstyle,fraction,two" glyph="onehalf"/>
-          <Ligature components="one.oldstyle,fraction,two.oldstyle" glyph="onehalf"/>
-          <Ligature components="one.oldstyle,slash,two" glyph="onehalf"/>
-          <Ligature components="one.oldstyle,slash,two.oldstyle" glyph="onehalf"/>
-        </LigatureSet>
-      </LigatureSubst>
+      <Lookup index="0">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="one">
+            <Ligature components="one,fraction,two" glyph="onehalf"/>
+            <Ligature components="one,fraction,two.oldstyle" glyph="onehalf"/>
+            <Ligature components="one,slash,two" glyph="onehalf"/>
+            <Ligature components="one,slash,two.oldstyle" glyph="onehalf"/>
+          </LigatureSet>
+          <LigatureSet glyph="one.oldstyle">
+            <Ligature components="one.oldstyle,fraction,two" glyph="onehalf"/>
+            <Ligature components="one.oldstyle,fraction,two.oldstyle" glyph="onehalf"/>
+            <Ligature components="one.oldstyle,slash,two" glyph="onehalf"/>
+            <Ligature components="one.oldstyle,slash,two.oldstyle" glyph="onehalf"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
     </LookupList>
   </GSUB>
 

--- a/Lib/fontTools/feaLib/testdata/spec5d2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d2.ttx
@@ -37,16 +37,21 @@
     </FeatureList>
     <LookupList>
       <!-- LookupCount=1 -->
-      <LigatureSubst index="0" Format="1">
-        <LigatureSet glyph="f">
-          <Ligature components="f,f,i" glyph="f_f_i"/>
-          <Ligature components="f,f" glyph="f_f"/>
-          <Ligature components="f,i" glyph="f_i"/>
-        </LigatureSet>
-        <LigatureSet glyph="o">
-          <Ligature components="o,f,f,i" glyph="o_f_f_i"/>
-        </LigatureSet>
-      </LigatureSubst>
+      <Lookup index="0">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="f">
+            <Ligature components="f,f,i" glyph="f_f_i"/>
+            <Ligature components="f,f" glyph="f_f"/>
+            <Ligature components="f,i" glyph="f_i"/>
+          </LigatureSet>
+          <LigatureSet glyph="o">
+            <Ligature components="o,f,f,i" glyph="o_f_f_i"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
     </LookupList>
   </GSUB>
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -120,8 +120,8 @@ class BaseConverter(object):
 		raise NotImplementedError(self)
 
 	def writeArray(self, writer, font, tableDict, values):
-		for i in range(len(values)):
-			self.write(writer, font, tableDict, values[i], i)
+		for i, value in enumerate(values):
+			self.write(writer, font, tableDict, value, i)
 
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		"""Write a value to the writer."""


### PR DESCRIPTION
the `feaLib.builder.Builder.makeTable` is missing one level in the structure of OpenType layout tables.

`table.LookupList.Lookup` in GSUB is being built as a list of lookup *subtables* (e.g. `LigatureSubst`, `AlternateSubst`, etc.). Instead, it should be a list of `Lookup` objects, each having a `SubTable` attribute containing the list of subtables, as well as `LookupType`, `LookupFlag`, `SubTableCount`, etc.

https://github.com/behdad/fonttools/blob/master/Lib/fontTools/ttLib/tables/otData.py#L88

@brawer this PR is just to show the issue with code, feel free to close this and fix it the way you like.
Thanks for the good work!