### PR TITLE
Build ltag table also with Python 2.7

### DIFF
--- a/Lib/fontTools/ttLib/tables/_l_t_a_g.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g.py
@@ -28,7 +28,7 @@ class table__l_t_a_g(DefaultTable.DefaultTable):
 				stringPool = stringPool + tag
 			offset = offset + 12 + len(self.tags) * 4
 			dataList.append(struct.pack(">HH", offset, len(tag)))
-		dataList.append(stringPool)
+		dataList.append(stringPool.encode("ascii"))
 		return bytesjoin(dataList)
 
 	def toXML(self, writer, ttFont):

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g_test.py
@@ -17,7 +17,9 @@ class Test_l_t_a_g(unittest.TestCase):
 		self.assertEqual(1, table.version)
 		self.assertEqual(0, table.flags)
 		self.assertEqual(self.TAGS_, table.tags)
-		self.assertEqual(self.DATA_, table.compile(ttFont=None))
+		compiled = table.compile(ttFont=None)
+		self.assertEqual(self.DATA_, compiled)
+		self.assertIsInstance(compiled, bytes)
 
 	def test_fromXML(self):
 		table = table__l_t_a_g()


### PR DESCRIPTION
Before this change, TTX (when running in Python 2.7) would fail
to compile a font if the input contained an `ltag` section.
With Python 3, it worked perfectly fine even before this change.

Resolves https://github.com/behdad/fonttools/issues/357