### PR TITLE
[otTables] Simplify API for MultipleSubst

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -401,20 +401,15 @@ def subset_glyphs(self, s):
 
 @_add_method(otTables.MultipleSubst)
 def closure_glyphs(self, s, cur_glyphs):
-    indices = self.Coverage.intersect(cur_glyphs)
-    _set_update(s.glyphs, *(self.Sequence[i].Substitute for i in indices))
+    for glyph, subst in self.mapping.items():
+        if glyph in cur_glyphs:
+            _set_update(s.glyphs, subst)
 
 @_add_method(otTables.MultipleSubst)
 def subset_glyphs(self, s):
-    indices = self.Coverage.subset(s.glyphs)
-    self.Sequence = [self.Sequence[i] for i in indices]
-    # Now drop rules generating glyphs we don't want
-    indices = [i for i,seq in enumerate(self.Sequence)
-               if all(sub in s.glyphs for sub in seq.Substitute)]
-    self.Sequence = [self.Sequence[i] for i in indices]
-    self.Coverage.remap(indices)
-    self.SequenceCount = len(self.Sequence)
-    return bool(self.SequenceCount)
+    self.mapping = {g:v for g,v in self.mapping.items()
+                    if g in s.glyphs and all(sub in s.glyphs for sub in v)}
+    return bool(self.mapping)
 
 @_add_method(otTables.AlternateSubst)
 def closure_glyphs(self, s, cur_glyphs):

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -203,6 +203,55 @@ class SingleSubst(FormatSwitchingBaseTable):
 		mapping[attrs["in"]] = attrs["out"]
 
 
+class MultipleSubst(FormatSwitchingBaseTable):
+	def postRead(self, rawTable, font):
+		mapping = {}
+		if self.Format == 1:
+			glyphs = _getGlyphsFromCoverageTable(rawTable["Coverage"])
+			subst = [s.Substitute for s in rawTable["Sequence"]]
+			mapping = dict(zip(glyphs, subst))
+		else:
+			assert 0, "unknown format: %s" % self.Format
+		self.mapping = mapping
+		del self.Format # Don't need this anymore
+
+	def preWrite(self, font):
+		mapping = getattr(self, "mapping", None)
+		if mapping is None:
+			mapping = self.mapping = {}
+		cov = Coverage()
+		cov.glyphs = sorted(list(mapping.keys()), key=font.getGlyphID)
+		self.Format = 1
+		rawTable = {
+                        "Coverage": cov,
+                        "Sequence": [self.makeSequence_(mapping[glyph])
+                                     for glyph in cov.glyphs],
+                }
+		return rawTable
+
+	def toXML2(self, xmlWriter, font):
+		items = sorted(self.mapping.items())
+		for inGlyph, outGlyphs in items:
+			out = ",".join(outGlyphs)
+			xmlWriter.simpletag("Substitution",
+					[("in", inGlyph), ("out", out)])
+			xmlWriter.newline()
+
+	def fromXML(self, name, attrs, content, font):
+		mapping = getattr(self, "mapping", None)
+		if mapping is None:
+			mapping = {}
+			self.mapping = mapping
+		outGlyphs = attrs["out"].split(",")
+		mapping[attrs["in"]] = [g.strip() for g in outGlyphs]
+
+	@staticmethod
+	def makeSequence_(g):
+		seq = Sequence()
+		seq.Substitute = g
+		return seq
+
+
 class ClassDef(FormatSwitchingBaseTable):
 
 	def postRead(self, rawTable, font):


### PR DESCRIPTION
Resolves https://github.com/behdad/fonttools/issues/355

For making sure that `pyftsubset` still works after this change,
I have done the following steps:

* invoked Adobe's `makeotf` tool to build a custom font with a
  MultipleSubst lookup. This lookup decomposes two two ligatures,
  `c_t` and `f_f_i`, into their respective components.

* invoked the `pyftsubset` tool to produce a subset font with just
  the `c_t` ligature;

* checked with `ttx` that the newly produced subset font contains
  the requested `c_t` ligature and its components `c` and `t`,
  but does not contain not any of `f_f_i`, `f`, or `i`.