### PR TITLE
Support TTX format for `MultipleSubst` of FontTools 3.0 and earlier

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -242,6 +242,23 @@ class MultipleSubst(FormatSwitchingBaseTable):
 		if mapping is None:
 			mapping = {}
 			self.mapping = mapping
+
+		# TTX v3.0 and earlier.
+		if name == "Coverage":
+			self.old_coverage_ = [
+				element_attrs["value"]
+				for element_name, element_attrs, _ in content
+				if element_name == "Glyph"]
+			return
+		if name == "Sequence":
+			glyph = self.old_coverage_[int(attrs["index"])]
+			mapping[glyph] = [
+				element_attrs["value"]
+				for element_name, element_attrs, _ in content
+				if element_name == "Substitute"]
+			return
+
+                # TTX v3.1 and later.
 		outGlyphs = attrs["out"].split(",")
 		mapping[attrs["in"]] = [g.strip() for g in outGlyphs]
 

--- a/Lib/fontTools/ttLib/tables/otTables_test.py
+++ b/Lib/fontTools/ttLib/tables/otTables_test.py
@@ -142,6 +142,24 @@ class MultipleSubstTest(unittest.TestCase):
         self.assertEqual(table.mapping,
                          {'c_t': ['c', 't'], 'f_f_i': ['f', 'f', 'i']})
 
+    def test_fromXML_oldFormat(self):
+        table = otTables.MultipleSubst()
+        table.fromXML("Coverage", {}, [
+            ("Glyph", {"value": "c_t"}, []),
+            ("Glyph", {"value": "f_f_i"}, [])
+        ], self.font)
+        table.fromXML("Sequence", {"index": "0"}, [
+            ("Substitute", {"index": "0", "value": "c"}, []),
+            ("Substitute", {"index": "1", "value": "t"}, [])
+        ], self.font)
+        table.fromXML("Sequence", {"index": "1"}, [
+            ("Substitute", {"index": "0", "value": "f"}, []),
+            ("Substitute", {"index": "1", "value": "f"}, []),
+            ("Substitute", {"index": "2", "value": "i"}, [])
+        ], self.font)
+        self.assertEqual(table.mapping,
+                         {'c_t': ['c', 't'], 'f_f_i': ['f', 'f', 'i']})
+
 
 class LigatureSubstTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix a backwards compatibility problem introduced by https://github.com/behdad/fonttools/commit/1356a6775b174853e893484c737a9ee0bcf6d0fd (pull request https://github.com/behdad/fonttools/pull/364), where new versions of FontTools would not be able to process `<MultipleSubst>` elements in TTX files generated by older FontTools releases.

Resolves https://github.com/behdad/fonttools/issues/355.