### PR TITLE
meta table: 'dlng' and 'slng' data is text

### DIFF
--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -80,14 +80,24 @@ class table__m_e_t_a(DefaultTable.DefaultTable):
 
     def toXML(self, writer, ttFont, progress=None):
         for tag in sorted(self.data.keys()):
-            writer.begintag("hexdata", tag=tag)
-            writer.newline()
-            writer.dumphex(self.data[tag])
-            writer.endtag("hexdata")
-            writer.newline()
+            if tag in ["dlng", "slng"]:
+                writer.begintag("text", tag=tag)
+                writer.newline()
+                writer.write(self.data[tag])
+                writer.newline()
+                writer.endtag("text")
+                writer.newline()
+            else:
+                writer.begintag("hexdata", tag=tag)
+                writer.newline()
+                writer.dumphex(self.data[tag])
+                writer.endtag("hexdata")
+                writer.newline()
 
     def fromXML(self, name, attrs, content, ttFont):
         if name == "hexdata":
             self.data[attrs["tag"]] = readHex(content)
+        elif name == "text" and attrs["tag"] in ["dlng", "slng"]:
+            self.data[attrs["tag"]] = strjoin(content).strip()
         else:
             raise TTLibError("can't handle '%s' element" % name)

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -54,6 +54,8 @@ class table__m_e_t_a(DefaultTable.DefaultTable):
             tag = dataMap["tag"]
             offset = dataMap["dataOffset"]
             self.data[tag] = data[offset : offset + dataMap["dataLength"]]
+            if tag in ["dlng", "slng"]:
+                self.data[tag] = self.data[tag].decode("utf-8")
 
     def compile(self, ttFont):
         keys = sorted(self.data.keys())
@@ -68,7 +70,10 @@ class table__m_e_t_a(DefaultTable.DefaultTable):
         dataMaps = []
         dataBlocks = []
         for tag in keys:
-            data = self.data[tag]
+            if tag in ["dlng", "slng"]:
+                data = self.data[tag].encode("utf-8")
+            else:
+                data = self.data[tag]
             dataMaps.append(sstruct.pack(DATA_MAP_FORMAT, {
                 "tag": tag,
                 "dataOffset": dataOffset,

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
@@ -43,11 +43,11 @@ class MetaTableTest(unittest.TestCase):
     def test_decompile_text(self):
         table = table__m_e_t_a()
         table.decompile(META_DATA_TEXT, ttFont={"meta": table})
-        self.assertEqual({"dlng": b"Latn,Grek,Cyrl"}, table.data)
+        self.assertEqual({"dlng": u"Latn,Grek,Cyrl"}, table.data)
 
     def test_compile_text(self):
         table = table__m_e_t_a()
-        table.data["dlng"] = b"Latn,Grek,Cyrl"
+        table.data["dlng"] = u"Latn,Grek,Cyrl"
         self.assertEqual(META_DATA_TEXT, table.compile(ttFont={"meta": table}))
 
     def test_toXML(self):
@@ -73,7 +73,7 @@ class MetaTableTest(unittest.TestCase):
 
     def test_toXML_text(self):
         table = table__m_e_t_a()
-        table.data["dlng"] = b"Latn,Grek,Cyrl"
+        table.data["dlng"] = u"Latn,Grek,Cyrl"
         writer = XMLWriter(BytesIO())
         table.toXML(writer, {"meta": table})
         xml = writer.file.getvalue().decode("utf-8")
@@ -90,7 +90,7 @@ class MetaTableTest(unittest.TestCase):
                 '    Latn,Grek,Cyrl'
                 '</text>'):
             table.fromXML(name, attrs, content, ttFont=None)
-        self.assertEqual({"dlng": "Latn,Grek,Cyrl"}, table.data)
+        self.assertEqual({"dlng": u"Latn,Grek,Cyrl"}, table.data)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
@@ -21,6 +21,13 @@ META_DATA = deHexStr(
     "00 00 00 01 00 00 00 00 00 00 00 1C 00 00 00 01 "
     "54 45 53 54 00 00 00 1C 00 00 00 04 CA FE BE EF")
 
+# The 'dlng' tag with text data containing BCP 47 comma-separated
+# or comma and space-separated tags). The 'slng' tag would also expect text
+# data instead of binary data.
+META_DATA_TEXT = deHexStr(
+    "00 00 00 01 00 00 00 00 00 00 00 1C 00 00 00 01 "
+    "64 6C 6E 67 00 00 00 1C 00 00 00 0E 4C 61 74 6E "
+    "2C 47 72 65 6B 2C 43 79 72 6C")
 
 class MetaTableTest(unittest.TestCase):
     def test_decompile(self):
@@ -32,6 +39,16 @@ class MetaTableTest(unittest.TestCase):
         table = table__m_e_t_a()
         table.data["TEST"] = b"\xCA\xFE\xBE\xEF"
         self.assertEqual(META_DATA, table.compile(ttFont={"meta": table}))
+
+    def test_decompile_text(self):
+        table = table__m_e_t_a()
+        table.decompile(META_DATA_TEXT, ttFont={"meta": table})
+        self.assertEqual({"dlng": b"Latn,Grek,Cyrl"}, table.data)
+
+    def test_compile_text(self):
+        table = table__m_e_t_a()
+        table.data["dlng"] = b"Latn,Grek,Cyrl"
+        self.assertEqual(META_DATA_TEXT, table.compile(ttFont={"meta": table}))
 
     def test_toXML(self):
         table = table__m_e_t_a()
@@ -53,6 +70,27 @@ class MetaTableTest(unittest.TestCase):
                 '</hexdata>'):
             table.fromXML(name, attrs, content, ttFont=None)
         self.assertEqual({"TEST": b"\xCA\xFE\xBE\xEF"}, table.data)
+
+    def test_toXML_text(self):
+        table = table__m_e_t_a()
+        table.data["dlng"] = b"Latn,Grek,Cyrl"
+        writer = XMLWriter(BytesIO())
+        table.toXML(writer, {"meta": table})
+        xml = writer.file.getvalue().decode("utf-8")
+        self.assertEqual([
+            '<text tag="dlng">',
+            'Latn,Grek,Cyrl',
+            '</text>'
+        ], [line.strip() for line in xml.splitlines()][1:])
+
+    def test_fromXML_text(self):
+        table = table__m_e_t_a()
+        for name, attrs, content in parseXML(
+                '<text tag="dlng">'
+                '    Latn,Grek,Cyrl'
+                '</text>'):
+            table.fromXML(name, attrs, content, ttFont=None)
+        self.assertEqual({"dlng": "Latn,Grek,Cyrl"}, table.data)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a_test.py
@@ -21,13 +21,15 @@ META_DATA = deHexStr(
     "00 00 00 01 00 00 00 00 00 00 00 1C 00 00 00 01 "
     "54 45 53 54 00 00 00 1C 00 00 00 04 CA FE BE EF")
 
-# The 'dlng' tag with text data containing BCP 47 comma-separated
-# or comma and space-separated tags). The 'slng' tag would also expect text
-# data instead of binary data.
+# The 'dlng' and 'slng' tag with text data containing "augmented" BCP 47
+# comma-separated or comma-space-separated tags. These should be UTF-8 encoded
+# text.
 META_DATA_TEXT = deHexStr(
-    "00 00 00 01 00 00 00 00 00 00 00 1C 00 00 00 01 "
-    "64 6C 6E 67 00 00 00 1C 00 00 00 0E 4C 61 74 6E "
-    "2C 47 72 65 6B 2C 43 79 72 6C")
+    "00 00 00 01 00 00 00 00 00 00 00 28 00 00 00 02 "
+    "64 6C 6E 67 00 00 00 28 00 00 00 0E 73 6C 6E 67 "
+    "00 00 00 36 00 00 00 0E 4C 61 74 6E 2C 47 72 65 "
+    "6B 2C 43 79 72 6C 4C 61 74 6E 2C 47 72 65 6B 2C "
+    "43 79 72 6C")
 
 class MetaTableTest(unittest.TestCase):
     def test_decompile(self):
@@ -43,11 +45,13 @@ class MetaTableTest(unittest.TestCase):
     def test_decompile_text(self):
         table = table__m_e_t_a()
         table.decompile(META_DATA_TEXT, ttFont={"meta": table})
-        self.assertEqual({"dlng": u"Latn,Grek,Cyrl"}, table.data)
+        self.assertEqual({"dlng": u"Latn,Grek,Cyrl",
+                          "slng": u"Latn,Grek,Cyrl"}, table.data)
 
     def test_compile_text(self):
         table = table__m_e_t_a()
         table.data["dlng"] = u"Latn,Grek,Cyrl"
+        table.data["slng"] = u"Latn,Grek,Cyrl"
         self.assertEqual(META_DATA_TEXT, table.compile(ttFont={"meta": table}))
 
     def test_toXML(self):


### PR DESCRIPTION
According to https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6meta.html
'dlng' design languages and 'slng' supported languages are comma-separated or comma-space-separated "augmented" BCP 47 language tags.

```xml
<hexdata tag="dlng">
  4c61746e 2c477265 6b2c4379 726c2c41
  726d6e2c 48656272 2c417261 622c5468
  6169
</hexdata>
```
can be displayed as
```xml
<text tag="dlng">
  Latn,Grek,Cyrl,Armn,Hebr,Arab,Thai
</text>
```