### PR TITLE
[trak] add AAT 'trak' table support

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.xmlWriter import XMLWriter
 
 
 def parseXML(xmlSnippet):
@@ -40,3 +41,18 @@ class TestXMLReader_(object):
 
     def addCharacterData_(self, data):
         self.stack[-1][2].append(data)
+
+
+def getXML(obj, ttFont):
+    """Call the object's toXML() method and return the writer's content as string.
+    Result is stripped of XML declaration and OS-specific newline characters.
+    """
+    writer = XMLWriter(BytesIO())
+    # don't write OS-specific new lines
+    writer.newlinestr = writer.totype('')
+    # erase XML declaration
+    writer.file.seek(0)
+    writer.file.truncate()
+    obj.toXML(writer, ttFont)
+    xml = writer.file.getvalue().decode("utf-8")
+    return xml

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -66,6 +66,7 @@ def _moduleFinderHint():
 	from . import _p_o_s_t
 	from . import _p_r_e_p
 	from . import _s_b_i_x
+	from . import _t_r_a_k
 	from . import _v_h_e_a
 	from . import _v_m_t_x
 

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -197,16 +197,12 @@ class TrackData(MutableMapping):
 	def toXML(self, writer, ttFont, progress=None):
 		nTracks = len(self)
 		nSizes = len(self.sizes())
-		if not any([nTracks, nSizes]):
-			writer.comment("nTracks=0, nSizes=0")
-			writer.newline()
-		else:
-			writer.comment("nTracks=%d, nSizes=%d" % (nTracks, nSizes))
-			writer.newline()
-			for track, entry in sorted(self.items()):
-				assert entry.nameIndex is not None
-				entry.track = track
-				entry.toXML(writer, ttFont)
+		writer.comment("nTracks=%d, nSizes=%d" % (nTracks, nSizes))
+		writer.newline()
+		for track, entry in sorted(self.items()):
+			assert entry.nameIndex is not None
+			entry.track = track
+			entry.toXML(writer, ttFont)
 
 	def fromXML(self, name, attrs, content, ttFont):
 		if name != 'trackEntry':

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,0 +1,319 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
+from fontTools.misc.textTools import safeEval
+from fontTools.ttLib import TTLibError
+from . import DefaultTable
+import struct
+try:
+	from collections.abc import MutableMapping
+except ImportError:
+	from UserDict import DictMixin as MutableMapping
+
+
+# Apple's documentation of 'trak':
+# https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html
+
+TRAK_HEADER_FORMAT = """
+	> # big endian
+	version:     16.16F
+	format:      H
+	horizOffset: H
+	vertOffset:  H
+	reserved:    H
+"""
+
+TRAK_HEADER_FORMAT_SIZE = sstruct.calcsize(TRAK_HEADER_FORMAT)
+
+
+TRACK_DATA_FORMAT = """
+	> # big endian
+	nTracks:         H
+	nSizes:          H
+	sizeTableOffset: L
+"""
+
+TRACK_DATA_FORMAT_SIZE = sstruct.calcsize(TRACK_DATA_FORMAT)
+
+
+TRACK_TABLE_ENTRY_FORMAT = """
+	> # big endian
+	track:      16.16F
+	nameIndex:       H
+	offset:          H
+"""
+
+TRACK_TABLE_ENTRY_FORMAT_SIZE = sstruct.calcsize(TRACK_TABLE_ENTRY_FORMAT)
+
+
+# size values are actually '16.16F' fixed-point values, but here I do the
+# fixedToFloat conversion manually instead of relying on sstruct
+SIZE_VALUE_FORMAT = ">l"
+SIZE_VALUE_FORMAT_SIZE = struct.calcsize(SIZE_VALUE_FORMAT)
+
+# per-Size values are in 'FUnits', i.e. 16-bit signed integers
+PER_SIZE_VALUE_FORMAT = ">h"
+PER_SIZE_VALUE_FORMAT_SIZE = struct.calcsize(PER_SIZE_VALUE_FORMAT)
+
+
+class table__t_r_a_k(DefaultTable.DefaultTable):
+	dependencies = ['name']
+
+	def compile(self, ttFont):
+		dataList = []
+		offset = TRAK_HEADER_FORMAT_SIZE
+		for direction in ('horiz', 'vert'):
+			trackData = getattr(self, direction + 'Data', TrackData())
+			offsetName = direction + 'Offset'
+			# set offset to 0 if None or empty
+			if not trackData:
+				setattr(self, offsetName, 0)
+				continue
+			# TrackData table format must be longword aligned
+			alignedOffset = (offset + 3) & ~3
+			padding, offset = b"\x00"*(alignedOffset - offset), alignedOffset
+			setattr(self, offsetName, offset)
+
+			data = trackData.compile(offset)
+			offset += len(data)
+			dataList.append(padding + data)
+
+		self.reserved = 0
+		tableData = bytesjoin([sstruct.pack(TRAK_HEADER_FORMAT, self)] + dataList)
+		return tableData
+
+	def decompile(self, data, ttFont):
+		sstruct.unpack(TRAK_HEADER_FORMAT, data[:TRAK_HEADER_FORMAT_SIZE], self)
+		for direction in ('horiz', 'vert'):
+			trackData = TrackData()
+			offset = getattr(self, direction + 'Offset')
+			if offset != 0:
+				trackData.decompile(data, offset)
+			setattr(self, direction + 'Data', trackData)
+
+	def toXML(self, writer, ttFont, progress=None):
+		writer.simpletag('version', value=self.version)
+		writer.newline()
+		writer.simpletag('format', value=self.format)
+		writer.newline()
+		for direction in ('horiz', 'vert'):
+			dataName = direction + 'Data'
+			writer.begintag(dataName)
+			writer.newline()
+			trackData = getattr(self, dataName, TrackData())
+			trackData.toXML(writer, ttFont)
+			writer.endtag(dataName)
+			writer.newline()
+
+	def fromXML(self, name, attrs, content, ttFont):
+		if name == 'version':
+			self.version = safeEval(attrs['value'])
+		elif name == 'format':
+			self.format = safeEval(attrs['value'])
+		elif name in ('horizData', 'vertData'):
+			trackData = TrackData()
+			setattr(self, name, trackData)
+			for element in content:
+				if not isinstance(element, tuple):
+					continue
+				name, attrs, content_ = element
+				trackData.fromXML(name, attrs, content_, ttFont)
+
+
+class TrackData(MutableMapping):
+
+	def __init__(self, initialdata={}):
+		self._map = dict(initialdata)
+
+	def compile(self, offset):
+		nTracks = len(self)
+		sizes = self.sizes()
+		nSizes = len(sizes)
+
+		# offset to the start of the size subtable
+		offset += TRACK_DATA_FORMAT_SIZE + TRACK_TABLE_ENTRY_FORMAT_SIZE*nTracks
+		trackDataHeader = sstruct.pack(
+			TRACK_DATA_FORMAT,
+			{'nTracks': nTracks, 'nSizes': nSizes, 'sizeTableOffset': offset})
+
+		entryDataList = []
+		perSizeDataList = []
+		# offset to per-size tracking values
+		offset += SIZE_VALUE_FORMAT_SIZE*nSizes
+		# sort track table entries by track value
+		for track, entry in sorted(self.items()):
+			assert entry.nameIndex is not None
+			entry.track = track
+			entry.offset = offset
+			entryDataList += [sstruct.pack(TRACK_TABLE_ENTRY_FORMAT, entry)]
+			# sort per-size values by size
+			for size, value in sorted(entry.items()):
+				perSizeDataList += [struct.pack(PER_SIZE_VALUE_FORMAT, value)]
+			offset += PER_SIZE_VALUE_FORMAT_SIZE*nSizes
+		# sort size values
+		sizeDataList = [struct.pack(SIZE_VALUE_FORMAT, fl2fi(sv, 16)) for sv in sorted(sizes)]
+
+		data = bytesjoin([trackDataHeader] + entryDataList + sizeDataList + perSizeDataList)
+		return data
+
+	def decompile(self, data, offset):
+		# initial offset is from the start of trak table to the current TrackData
+		trackDataHeader = data[offset:offset+TRACK_DATA_FORMAT_SIZE]
+		if len(trackDataHeader) != TRACK_DATA_FORMAT_SIZE:
+			raise TTLibError('not enough data to decompile TrackData header')
+		sstruct.unpack(TRACK_DATA_FORMAT, trackDataHeader, self)
+		offset += TRACK_DATA_FORMAT_SIZE
+
+		nSizes = self.nSizes
+		sizeTableOffset = self.sizeTableOffset
+		sizeTable = []
+		for i in range(nSizes):
+			sizeValueData = data[sizeTableOffset:sizeTableOffset+SIZE_VALUE_FORMAT_SIZE]
+			if len(sizeValueData) < SIZE_VALUE_FORMAT_SIZE:
+				raise TTLibError('not enough data to decompile TrackData size subtable')
+			sizeValue, = struct.unpack(SIZE_VALUE_FORMAT, sizeValueData)
+			sizeTable.append(fi2fl(sizeValue, 16))
+			sizeTableOffset += SIZE_VALUE_FORMAT_SIZE
+
+		for i in range(self.nTracks):
+			entry = TrackTableEntry()
+			entryData = data[offset:offset+TRACK_TABLE_ENTRY_FORMAT_SIZE]
+			if len(entryData) < TRACK_TABLE_ENTRY_FORMAT_SIZE:
+				raise TTLibError('not enough data to decompile TrackTableEntry record')
+			sstruct.unpack(TRACK_TABLE_ENTRY_FORMAT, entryData, entry)
+			perSizeOffset = entry.offset
+			for j in range(nSizes):
+				size = sizeTable[j]
+				perSizeValueData = data[perSizeOffset:perSizeOffset+PER_SIZE_VALUE_FORMAT_SIZE]
+				if len(perSizeValueData) < PER_SIZE_VALUE_FORMAT_SIZE:
+					raise TTLibError('not enough data to decompile per-size track values')
+				perSizeValue, = struct.unpack(PER_SIZE_VALUE_FORMAT, perSizeValueData)
+				entry[size] = perSizeValue
+				perSizeOffset += PER_SIZE_VALUE_FORMAT_SIZE
+			self[entry.track] = entry
+			offset += TRACK_TABLE_ENTRY_FORMAT_SIZE
+
+	def toXML(self, writer, ttFont, progress=None):
+		nTracks = len(self)
+		nSizes = len(self.sizes())
+		if not any([nTracks, nSizes]):
+			writer.comment("nTracks=0, nSizes=0")
+			writer.newline()
+		else:
+			writer.comment("nTracks=%d, nSizes=%d" % (nTracks, nSizes))
+			writer.newline()
+			for track, entry in sorted(self.items()):
+				assert entry.nameIndex is not None
+				entry.track = track
+				entry.toXML(writer, ttFont)
+
+	def fromXML(self, name, attrs, content, ttFont):
+		if name != 'trackEntry':
+			return
+		entry = TrackTableEntry()
+		entry.fromXML(name, attrs, content, ttFont)
+		self[entry.track] = entry
+
+	def sizes(self):
+		if not self:
+			return frozenset()
+		tracks = list(self.tracks())
+		sizes = self[tracks.pop(0)].sizes()
+		for track in tracks:
+			entrySizes = self[track].sizes()
+			if sizes != entrySizes:
+				raise TTLibError(
+					"'trak' table entries must specify the same sizes: "
+					"%s != %s" % (sorted(sizes), sorted(entrySizes)))
+		return frozenset(sizes)
+
+	def __getitem__(self, track):
+		return self._map[track]
+
+	def __delitem__(self, track):
+		del self._map[track]
+
+	def __setitem__(self, track, entry):
+		self._map[track] = entry
+
+	def __len__(self):
+		return len(self._map)
+
+	def __iter__(self):
+		return iter(self._map)
+
+	def keys(self):
+		return self._map.keys()
+
+	tracks = keys
+
+	def __repr__(self):
+		return "TrackData({})".format(self._map if self else "")
+
+
+class TrackTableEntry(MutableMapping):
+
+	def __init__(self, values={}, nameIndex=None):
+		self.nameIndex = nameIndex
+		self._map = dict(values)
+
+	def toXML(self, writer, ttFont, progress=None):
+		name = ttFont["name"].getDebugName(self.nameIndex)
+		writer.begintag(
+			"trackEntry",
+			(('value', self.track), ('nameIndex', self.nameIndex)))
+		writer.newline()
+		if name:
+			writer.comment(name)
+			writer.newline()
+		for size, perSizeValue in sorted(self.items()):
+			writer.simpletag("track", size=size, value=perSizeValue)
+			writer.newline()
+		writer.endtag("trackEntry")
+		writer.newline()
+
+	def fromXML(self, name, attrs, content, ttFont):
+		self.track = safeEval(attrs['value'])
+		self.nameIndex = safeEval(attrs['nameIndex'])
+		for element in content:
+			if not isinstance(element, tuple):
+				continue
+			name, attrs, _ = element
+			if name != 'track':
+				continue
+			size = safeEval(attrs['size'])
+			self[size] = safeEval(attrs['value'])
+
+	def __getitem__(self, size):
+		return self._map[size]
+
+	def __delitem__(self, size):
+		del self._map[size]
+
+	def __setitem__(self, size, value):
+		self._map[size] = value
+
+	def __len__(self):
+		return len(self._map)
+
+	def __iter__(self):
+		return iter(self._map)
+
+	def keys(self):
+		return self._map.keys()
+
+	sizes = keys
+
+	def __repr__(self):
+		return "TrackTableEntry({}, nameIndex={})".format(self._map, self.nameIndex)
+
+	def __eq__(self, other):
+		if (isinstance(other, TrackTableEntry)
+				and self.nameIndex == other.nameIndex
+				and dict(self) == dict(other)):
+			return True
+		return False
+
+	def __ne__(self, other):
+		return not self.__eq__(other)

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k_test.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k_test.py
@@ -1,0 +1,334 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.testTools import parseXML, getXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, TTLibError
+from fontTools.ttLib.tables._t_r_a_k import *
+from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e, NameRecord
+import unittest
+
+
+# /Library/Fonts/Osaka.ttf from OSX has trak table with both horiz and vertData
+OSAKA_TRAK_TABLE_DATA = deHexStr(
+	'00 01 00 00 00 00 00 0c 00 40 00 00 00 03 00 02 00 00 00 2c ff ff '
+	'00 00 01 06 00 34 00 00 00 00 01 07 00 38 00 01 00 00 01 08 00 3c '
+	'00 0c 00 00 00 18 00 00 ff f4 ff f4 00 00 00 00 00 0c 00 0c 00 03 '
+	'00 02 00 00 00 60 ff ff 00 00 01 09 00 68 00 00 00 00 01 0a 00 6c '
+	'00 01 00 00 01 0b 00 70 00 0c 00 00 00 18 00 00 ff f4 ff f4 00 00 '
+	'00 00 00 0c 00 0c')
+
+# decompiled horizData and vertData entries from Osaka.ttf 
+OSAKA_HORIZ_TRACK_ENTRIES = {
+	-1.0: TrackTableEntry({24.0: -12, 12.0: -12}, nameIndex=262),
+	 0.0: TrackTableEntry({24.0: 0, 12.0: 0}, nameIndex=263),
+	 1.0: TrackTableEntry({24.0: 12, 12.0: 12}, nameIndex=264)
+	}
+
+OSAKA_VERT_TRACK_ENTRIES = {
+	-1.0: TrackTableEntry({24.0: -12, 12.0: -12}, nameIndex=265),
+	 0.0: TrackTableEntry({24.0: 0, 12.0: 0}, nameIndex=266),
+	 1.0: TrackTableEntry({24.0: 12, 12.0: 12}, nameIndex=267)
+	}
+
+OSAKA_TRAK_TABLE_XML = (
+	'<version value="1.0"/>'
+	'<format value="0"/>'
+	'<horizData>'
+	'  <!-- nTracks=3, nSizes=2 -->'
+	'  <trackEntry value="-1.0" nameIndex="262">'
+	'    <!-- Tight -->'
+	'    <track size="12.0" value="-12"/>'
+	'    <track size="24.0" value="-12"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="0.0" nameIndex="263">'
+	'    <!-- Normal -->'
+	'    <track size="12.0" value="0"/>'
+	'    <track size="24.0" value="0"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="1.0" nameIndex="264">'
+	'    <!-- Loose -->'
+	'    <track size="12.0" value="12"/>'
+	'    <track size="24.0" value="12"/>'
+	'  </trackEntry>'
+	'</horizData>'
+	'<vertData>'
+	'  <!-- nTracks=3, nSizes=2 -->'
+	'  <trackEntry value="-1.0" nameIndex="265">'
+	'    <!-- Tight -->'
+	'    <track size="12.0" value="-12"/>'
+	'    <track size="24.0" value="-12"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="0.0" nameIndex="266">'
+	'    <!-- Normal -->'
+	'    <track size="12.0" value="0"/>'
+	'    <track size="24.0" value="0"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="1.0" nameIndex="267">'
+	'    <!-- Loose -->'
+	'    <track size="12.0" value="12"/>'
+	'    <track size="24.0" value="12"/>'
+	'  </trackEntry>'
+	'</vertData>'
+	)
+
+# made-up table containing only vertData (no horizData)
+OSAKA_VERT_ONLY_TRAK_TABLE_DATA = deHexStr(
+	'00 01 00 00 00 00 00 00 00 0c 00 00 00 03 00 02 00 00 00 2c ff ff '
+	'00 00 01 09 00 34 00 00 00 00 01 0a 00 38 00 01 00 00 01 0b 00 3c '
+	'00 0c 00 00 00 18 00 00 ff f4 ff f4 00 00 00 00 00 0c 00 0c')
+
+OSAKA_VERT_ONLY_TRAK_TABLE_XML = (
+	'<version value="1.0"/>'
+	'<format value="0"/>'
+	'<horizData>'
+	'  <!-- nTracks=0, nSizes=0 -->'
+	'</horizData>'
+	'<vertData>'
+	'  <!-- nTracks=3, nSizes=2 -->'
+	'  <trackEntry value="-1.0" nameIndex="265">'
+	'    <!-- Tight -->'
+	'    <track size="12.0" value="-12"/>'
+	'    <track size="24.0" value="-12"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="0.0" nameIndex="266">'
+	'    <!-- Normal -->'
+	'    <track size="12.0" value="0"/>'
+	'    <track size="24.0" value="0"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="1.0" nameIndex="267">'
+	'    <!-- Loose -->'
+	'    <track size="12.0" value="12"/>'
+	'    <track size="24.0" value="12"/>'
+	'  </trackEntry>'
+	'</vertData>'
+	)
+
+
+# also /Library/Fonts/Skia.ttf contains a trak table with horizData
+SKIA_TRAK_TABLE_DATA = deHexStr(
+	'00 01 00 00 00 00 00 0c 00 00 00 00 00 03 00 05 00 00 00 2c ff ff '
+	'00 00 01 13 00 40 00 00 00 00 01 2f 00 4a 00 01 00 00 01 14 00 54 '
+	'00 09 00 00 00 0a 00 00 00 0c 00 00 00 12 00 00 00 13 00 00 ff f6 '
+	'ff e2 ff c4 ff c1 ff c1 00 0f 00 00 ff fb ff e7 ff e7 00 8c 00 82 '
+	'00 7d 00 73 00 73')
+
+SKIA_TRACK_ENTRIES = {
+	-1.0: TrackTableEntry(
+		{9.0: -10, 10.0: -30, 19.0: -63, 12.0: -60, 18.0: -63}, nameIndex=275),
+	 0.0: TrackTableEntry(
+	 	{9.0: 15, 10.0: 0, 19.0: -25, 12.0: -5, 18.0: -25}, nameIndex=303),
+	 1.0: TrackTableEntry(
+	 	{9.0: 140, 10.0: 130, 19.0: 115, 12.0: 125, 18.0: 115}, nameIndex=276)
+	}
+
+SKIA_TRAK_TABLE_XML = (
+	'<version value="1.0"/>'
+	'<format value="0"/>'
+	'<horizData>'
+	'  <!-- nTracks=3, nSizes=5 -->'
+	'  <trackEntry value="-1.0" nameIndex="275">'
+	'    <!-- Tight -->'
+	'    <track size="9.0" value="-10"/>'
+	'    <track size="10.0" value="-30"/>'
+	'    <track size="12.0" value="-60"/>'
+	'    <track size="18.0" value="-63"/>'
+	'    <track size="19.0" value="-63"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="0.0" nameIndex="303">'
+	'    <!-- Normal -->'
+	'    <track size="9.0" value="15"/>'
+	'    <track size="10.0" value="0"/>'
+	'    <track size="12.0" value="-5"/>'
+	'    <track size="18.0" value="-25"/>'
+	'    <track size="19.0" value="-25"/>'
+	'  </trackEntry>'
+	'  <trackEntry value="1.0" nameIndex="276">'
+	'    <!-- Loose -->'
+	'    <track size="9.0" value="140"/>'
+	'    <track size="10.0" value="130"/>'
+	'    <track size="12.0" value="125"/>'
+	'    <track size="18.0" value="115"/>'
+	'    <track size="19.0" value="115"/>'
+	'  </trackEntry>'
+	'</horizData>'
+	'<vertData>'
+	'  <!-- nTracks=0, nSizes=0 -->'
+	'</vertData>'
+	)
+
+
+class TrackingTableTest(unittest.TestCase):
+
+	def __init__(self, methodName):
+		unittest.TestCase.__init__(self, methodName)
+		# Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
+		# and fires deprecation warnings if a program uses the old name.
+		if not hasattr(self, "assertRaisesRegex"):
+			self.assertRaisesRegex = self.assertRaisesRegexp
+
+	def setUp(self):
+		table = table__t_r_a_k()
+		table.version = 1.0
+		table.format = 0
+		self.font = {'trak': table}
+
+	def test_compile_horiz(self):
+		table = self.font['trak']
+		table.horizData = TrackData(SKIA_TRACK_ENTRIES)
+		trakData = table.compile(self.font)
+		self.assertEqual(trakData, SKIA_TRAK_TABLE_DATA)
+
+	def test_compile_vert(self):
+		table = self.font['trak']
+		table.vertData = TrackData(OSAKA_VERT_TRACK_ENTRIES)
+		trakData = table.compile(self.font)
+		self.assertEqual(trakData, OSAKA_VERT_ONLY_TRAK_TABLE_DATA)
+
+	def test_compile_horiz_and_vert(self):
+		table = self.font['trak']
+		table.horizData = TrackData(OSAKA_HORIZ_TRACK_ENTRIES)
+		table.vertData = TrackData(OSAKA_VERT_TRACK_ENTRIES)
+		trakData = table.compile(self.font)
+		self.assertEqual(trakData, OSAKA_TRAK_TABLE_DATA)
+
+	def test_compile_longword_aligned(self):
+		table = self.font['trak']
+		# without padding, this 'horizData' would end up 46 byte long
+		table.horizData = TrackData({
+			0.0: TrackTableEntry(nameIndex=256, values={12.0: 0, 24.0: 0, 36.0: 0})
+			})
+		table.vertData = TrackData({
+			0.0: TrackTableEntry(nameIndex=257, values={12.0: 0, 24.0: 0, 36.0: 0})
+			})
+		trakData = table.compile(self.font)
+		self.assertTrue(table.vertOffset % 4 == 0)
+
+	def test_compile_sizes_mismatch(self):
+		table = self.font['trak']
+		table.horizData = TrackData({
+			-1.0: TrackTableEntry(nameIndex=256, values={9.0: -10, 10.0: -30}),
+			 0.0: TrackTableEntry(nameIndex=257, values={8.0: 20, 12.0: 0})
+			})
+		with self.assertRaisesRegex(TTLibError, 'entries must specify the same sizes'):
+			table.compile(self.font)
+
+	def test_decompile_horiz(self):
+		table = self.font['trak']
+		table.decompile(SKIA_TRAK_TABLE_DATA, self.font)
+		self.assertEqual(table.horizData, SKIA_TRACK_ENTRIES)
+		self.assertEqual(table.vertData, TrackData())
+
+	def test_decompile_vert(self):
+		table = self.font['trak']
+		table.decompile(OSAKA_VERT_ONLY_TRAK_TABLE_DATA, self.font)
+		self.assertEqual(table.horizData, TrackData())
+		self.assertEqual(table.vertData, OSAKA_VERT_TRACK_ENTRIES)
+
+	def test_decompile_horiz_and_vert(self):
+		table = self.font['trak']
+		table.decompile(OSAKA_TRAK_TABLE_DATA, self.font)
+		self.assertEqual(table.horizData, OSAKA_HORIZ_TRACK_ENTRIES)
+		self.assertEqual(table.vertData, OSAKA_VERT_TRACK_ENTRIES)
+
+	def test_roundtrip_decompile_compile(self):
+		for trakData in (
+				OSAKA_TRAK_TABLE_DATA,
+				OSAKA_VERT_ONLY_TRAK_TABLE_DATA,
+				SKIA_TRAK_TABLE_DATA):
+			table = table__t_r_a_k()
+			table.decompile(trakData, ttFont=None)
+			newTrakData = table.compile(ttFont=None)
+			self.assertEqual(trakData, newTrakData)
+
+	def test_fromXML_horiz(self):
+		table = self.font['trak']
+		for name, attrs, content in parseXML(SKIA_TRAK_TABLE_XML):
+			table.fromXML(name, attrs, content, self.font)
+		self.assertEqual(table.version, 1.0)
+		self.assertEqual(table.format, 0)
+		self.assertEqual(table.horizData, SKIA_TRACK_ENTRIES)
+		self.assertEqual(table.vertData, TrackData())
+
+	def test_fromXML_horiz_and_vert(self):
+		table = self.font['trak']
+		for name, attrs, content in parseXML(OSAKA_TRAK_TABLE_XML):
+			table.fromXML(name, attrs, content, self.font)
+		self.assertEqual(table.version, 1.0)
+		self.assertEqual(table.format, 0)
+		self.assertEqual(table.horizData, OSAKA_HORIZ_TRACK_ENTRIES)
+		self.assertEqual(table.vertData, OSAKA_VERT_TRACK_ENTRIES)
+
+	def test_fromXML_vert(self):
+		table = self.font['trak']
+		for name, attrs, content in parseXML(OSAKA_VERT_ONLY_TRAK_TABLE_XML):
+			table.fromXML(name, attrs, content, self.font)
+		self.assertEqual(table.version, 1.0)
+		self.assertEqual(table.format, 0)
+		self.assertEqual(table.horizData, TrackData())
+		self.assertEqual(table.vertData, OSAKA_VERT_TRACK_ENTRIES)
+
+	def test_toXML_horiz(self):
+		table = self.font['trak']
+		table.horizData = TrackData(SKIA_TRACK_ENTRIES)
+		add_name(self.font, 'Tight', nameID=275)
+		add_name(self.font, 'Normal', nameID=303)
+		add_name(self.font, 'Loose', nameID=276)
+		self.assertEqual(SKIA_TRAK_TABLE_XML, getXML(table, self.font))
+
+	def test_toXML_horiz_and_vert(self):
+		table = self.font['trak']
+		table.horizData = TrackData(OSAKA_HORIZ_TRACK_ENTRIES)
+		table.vertData = TrackData(OSAKA_VERT_TRACK_ENTRIES)
+		add_name(self.font, 'Tight', nameID=262)
+		add_name(self.font, 'Normal', nameID=263)
+		add_name(self.font, 'Loose', nameID=264)
+		add_name(self.font, 'Tight', nameID=265)
+		add_name(self.font, 'Normal', nameID=266)
+		add_name(self.font, 'Loose', nameID=267)
+		self.assertEqual(OSAKA_TRAK_TABLE_XML, getXML(table, self.font))
+
+	def test_toXML_vert(self):
+		table = self.font['trak']
+		table.vertData = TrackData(OSAKA_VERT_TRACK_ENTRIES)
+		add_name(self.font, 'Tight', nameID=265)
+		add_name(self.font, 'Normal', nameID=266)
+		add_name(self.font, 'Loose', nameID=267)
+		self.assertEqual(OSAKA_VERT_ONLY_TRAK_TABLE_XML, getXML(table, self.font))
+
+	def test_roundtrip_fromXML_toXML(self):
+		font = {}
+		add_name(font, 'Tight', nameID=275)
+		add_name(font, 'Normal', nameID=303)
+		add_name(font, 'Loose', nameID=276)
+		add_name(font, 'Tight', nameID=262)
+		add_name(font, 'Normal', nameID=263)
+		add_name(font, 'Loose', nameID=264)
+		add_name(font, 'Tight', nameID=265)
+		add_name(font, 'Normal', nameID=266)
+		add_name(font, 'Loose', nameID=267)
+		for input_xml in (
+				SKIA_TRAK_TABLE_XML,
+				OSAKA_TRAK_TABLE_XML,
+				OSAKA_VERT_ONLY_TRAK_TABLE_XML):
+			table = table__t_r_a_k()
+			font['trak'] = table
+			for name, attrs, content in parseXML(input_xml):
+				table.fromXML(name, attrs, content, font)
+			output_xml = getXML(table, font)
+			self.assertEqual(input_xml, output_xml)
+
+
+def add_name(font, string, nameID):
+	nameTable = font.get("name")
+	if nameTable is None:
+		nameTable = font["name"] = table__n_a_m_e()
+		nameTable.names = []
+	namerec = NameRecord()
+	namerec.nameID = nameID
+	namerec.string = string.encode('mac_roman')
+	namerec.platformID, namerec.platEncID, namerec.langID = (1, 0, 0)
+	nameTable.names.append(namerec)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/MetaTools/buildTableList.py
+++ b/MetaTools/buildTableList.py
@@ -4,13 +4,14 @@ import sys
 import os
 import glob
 from fontTools.ttLib import identifierToTag
+import textwrap
 
 
 fontToolsDir = os.path.dirname(os.path.dirname(os.path.join(os.getcwd(), sys.argv[0])))
 fontToolsDir= os.path.normpath(fontToolsDir)
 tablesDir = os.path.join(fontToolsDir,
 		"Lib", "fontTools", "ttLib", "tables")
-docFile = os.path.join(fontToolsDir, "Doc", "documentation.html")
+docFile = os.path.join(fontToolsDir, "README.md")
 
 names = glob.glob1(tablesDir, "*.py")
 
@@ -64,6 +65,9 @@ assert beginPos > 0
 beginPos = beginPos + len(begin) + 1
 endPos = doc.find(end)
 
-doc = doc[:beginPos] + ", ".join(tables[:-1]) + " and " + tables[-1] + "\n" + doc[endPos:]
+lines = textwrap.wrap(", ".join(tables[:-1]) + " and " + tables[-1], 66)
+blockquote = "\n".join(" "*4 + line for line in lines) + "\n"
+
+doc = doc[:beginPos] + blockquote + doc[endPos:]
 
 open(docFile, "w").write(doc)

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ These additional options include:
 ### The TTX file format
 
 The following tables are currently supported:
-
-    BASE, CBDT, CBLC, CFF, COLR, CPAL, DSIG, EBDT, EBLC, FFTM, GDEF, 
-    GMAP, GPKG, GPOS, GSUB, JSTF, LTSH, MATH, META, OS/2, SING, SVG, 
-    TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS, TSIV, 
-    VDMX, VORG, avar, cmap, cvt, feat, fpgm, fvar, gasp, glyf, gvar, 
-    hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, meta, name, post, 
-    prep, sbix, vhea, vmtx
-
+<!-- begin table list -->
+    BASE, CBDT, CBLC, CFF, COLR, CPAL, DSIG, EBDT, EBLC, FFTM, GDEF,
+    GMAP, GPKG, GPOS, GSUB, JSTF, LTSH, MATH, META, OS/2, SING, SVG,
+    TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS, TSIV,
+    VDMX, VORG, avar, cmap, cvt, feat, fpgm, fvar, gasp, glyf, gvar,
+    hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, meta, name, post,
+    prep, sbix, trak, vhea and vmtx
+<!-- end table list -->
 Other tables are dumped as hexadecimal data.
 
 TrueType fonts use glyph indices (GlyphIDs) to refer to glyphs in most places.


### PR DESCRIPTION
The internal structure of the new `table__t_r_a_k` looks like this: 

```python
table.__dict__ = {
		'version': 1.0,
		'format': 0,
		'horizData': TrackData({
			-1.0: TrackTableEntry(
				{9.0: -10, 10.0: -30, 19.0: -63, 12.0: -60, 18.0: -63}, nameIndex=275),
			 0.0: TrackTableEntry(
			 	{9.0: 15, 10.0: 0, 19.0: -25, 12.0: -5, 18.0: -25}, nameIndex=303),
			 1.0: TrackTableEntry(
			 	{9.0: 140, 10.0: 130, 19.0: 115, 12.0: 125, 18.0: 115}, nameIndex=276)
		}),
		'vertData': TrackData()
	}
```

Both `TrackData` and `TrackTableEntry` objects behave like dictionaries. They are nested inside each other, like a two-dimensional mapping: e.g., `table.horizData[-1.0][12.0] == -60`

Please let me know what you think,
Thanks.

/cc @jenskutilek @behdad @twardoch @moyogo @brawer 

Cf. https://github.com/behdad/fonttools/issues/375