### PR TITLE
[name] add setName method to table__n_a_m_e

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -111,6 +111,23 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		else:
 			return None
 
+	def setName(self, string, nameID, platformID, platEncID, langID):
+		if not hasattr(self, 'names'):
+			self.names = []
+		namerecord = self.getName(nameID, platformID, platEncID, langID)
+		exists = False if namerecord is None else True
+		if not exists:
+			namerecord = NameRecord()
+			namerecord.nameID = nameID
+			namerecord.platformID = platformID
+			namerecord.platEncID = platEncID
+			namerecord.langID = langID
+		encoding = namerecord.getEncoding()
+		namerecord.string = string.encode(encoding)
+		if not exists:
+			self.names.append(namerecord)
+
+
 class NameRecord(object):
 
 	def getEncoding(self, default='ascii'):

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
@@ -28,6 +28,19 @@ class NameTableTest(unittest.TestCase):
 		self.assertEqual("Sem Fracções", table.getDebugName(292))
 		self.assertEqual(None, table.getDebugName(999))
 
+	def test_setName(self):
+		table = table__n_a_m_e()
+		table.setName("Regular", 2, 1, 0, 0)
+		table.setName("Version 1.000", 5, 3, 1, 0x409)
+		table.setName("寬鬆", 276, 1, 2, 0x13)
+		self.assertEqual("Regular", str(table.getName(2, 1, 0, 0)))
+		self.assertEqual("Version 1.000", str(table.getName(5, 3, 1, 0x409)))
+		self.assertEqual("寬鬆", str(table.getName(276, 1, 2, 0x13)))
+		self.assertTrue(len(table.names) == 3)
+		table.setName("緊縮", 276, 1, 2, 0x13)
+		self.assertEqual("緊縮", str(table.getName(276, 1, 2, 0x13)))
+		self.assertTrue(len(table.names) == 3)
+
 
 class NameRecordTest(unittest.TestCase):
 

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e_test.py
@@ -33,12 +33,12 @@ class NameTableTest(unittest.TestCase):
 		table.setName("Regular", 2, 1, 0, 0)
 		table.setName("Version 1.000", 5, 3, 1, 0x409)
 		table.setName("寬鬆", 276, 1, 2, 0x13)
-		self.assertEqual("Regular", str(table.getName(2, 1, 0, 0)))
-		self.assertEqual("Version 1.000", str(table.getName(5, 3, 1, 0x409)))
-		self.assertEqual("寬鬆", str(table.getName(276, 1, 2, 0x13)))
+		self.assertEqual("Regular", table.getName(2, 1, 0, 0).toUnicode())
+		self.assertEqual("Version 1.000", table.getName(5, 3, 1, 0x409).toUnicode())
+		self.assertEqual("寬鬆", table.getName(276, 1, 2, 0x13).toUnicode())
 		self.assertTrue(len(table.names) == 3)
 		table.setName("緊縮", 276, 1, 2, 0x13)
-		self.assertEqual("緊縮", str(table.getName(276, 1, 2, 0x13)))
+		self.assertEqual("緊縮", table.getName(276, 1, 2, 0x13).toUnicode())
 		self.assertTrue(len(table.names) == 3)
 
 


### PR DESCRIPTION
The method takes a unicode `string`, `nameID`, `platformID`, `platEncID` and `langID`.
If the given name record already exists, its string is modified in place.
If it doesn't exist, a new record is created with the specified IDs and string.

As suggest by @brawer in https://github.com/anthrotype/fonttools/commit/380104c2288200aec1a7173162a3b3cfb29fc8f2#commitcomment-13534159