### PR TITLE
[psLib] revert to using StringIO.StringIO; temporarily drop support for Python3

### DIFF
--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -38,7 +38,13 @@ class PSTokenError(Exception): pass
 class PSError(Exception): pass
 
 
-class PSTokenizer(BytesIO):
+# StringIO.StringIO is only available in Python 2. The PSTokenizer class
+# attemps to access private attributes from the latter which are not available
+# in other file(-like) objects. Therefore, io.BytesIO (or io.StringIO) can't
+# be used as ready replacements. For now we must drop Python3 support in psLib,
+# and consequently in t1Lib, until we rewrite them for py23.
+# See: https://github.com/behdad/fonttools/issues/391
+class PSTokenizer(StringIO):
 
 	def getnexttoken(self,
 			# localize some stuff, for performance

--- a/Lib/fontTools/t1Lib.py
+++ b/Lib/fontTools/t1Lib.py
@@ -1,4 +1,4 @@
-"""fontTools.t1Lib.py -- Tools for PostScript Type 1 fonts
+"""fontTools.t1Lib.py -- Tools for PostScript Type 1 fonts (Python2 only)
 
 Functions for reading and writing raw Type 1 data:
 


### PR DESCRIPTION
This is only a temporary fix to revert a change which broke support for parsing Type1 fonts in Robofont. It turns out the whole t1Lib and psLib are not working with python3 because of other issues (as usual, unicode vs bytes), so they will need more than simply renaming StringIO to BytesIO...