### PR TITLE
[_p_o_s_t] remove max indices "reserved for future use"

### DIFF
--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -91,9 +91,7 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 		self.glyphOrder = glyphOrder = [""] * int(ttFont['maxp'].numGlyphs)
 		for glyphID in range(numGlyphs):
 			index = indices[glyphID]
-			if index > 32767: # reserved for future use; ignore
-				name = ""
-			elif index > 257:
+			if index > 257:
 				try:
 					name = extraNames[index-258]
 				except IndexError:
@@ -171,7 +169,6 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 				index = standardGlyphOrder.index(psName)
 			else:
 				index = 258 + len(extraNames)
-				assert index < 32768, "Too many glyph names for 'post' table format 2"
 				extraDict[psName] = len(extraNames)
 				extraNames.append(psName)
 			indices.append(index)


### PR DESCRIPTION
the third (2015) edition of ISO/IEC 14496-22 "Open Font Format" increased
the limit from 32767 to 65535 (and thus eliminated the reserved numbers).

(`array.array` will take care of raising the right `OverflowError` exception
so we don't need any further checking.)

Fixes https://github.com/behdad/fonttools/issues/348