### PR TITLE
[macCreatorType] fix KeyError raised by old version of xattr module

### DIFF
--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -21,7 +21,7 @@ def getMacCreatorAndType(path):
 	if xattr is not None:
 		try:
 			finderInfo = xattr.getxattr(path, 'com.apple.FinderInfo')
-		except IOError:
+		except (KeyError, IOError):
 			pass
 		else:
 			fileType = Tag(finderInfo[:4])


### PR DESCRIPTION
in version 0.6.4 as installed on OS X 10.10's built-in python2.7 (inside lib/extras), `xattr.getxattr` function raises `KeyError` whenever it cannot get the requested extended attribute. In the latest version, as available from PyPI (0.7.8), `xattr.getxattr` raises `IOError` instead. So we need to catch both.

Fixes issue in https://github.com/googlei18n/nototools/issues/113