### PR TITLE
[py23] fix ImportError when trying to import names when already defined

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -4,17 +4,17 @@ from __future__ import print_function, division, absolute_import
 import sys
 
 try:
-	basestring
+	basestring = basestring
 except NameError:
 	basestring = str
 
 try:
-	unicode
+	unicode = unicode
 except NameError:
 	unicode = str
 
 try:
-	unichr
+	unichr = unichr
 
 	if sys.maxunicode < 0x10FFFF:
 		# workarounds for Python 2 "narrow" builds with UCS2-only support.


### PR DESCRIPTION
When one does `from fontTools.misc.py23 import *`, everything seems to work fine.

However, linters will complain when one uses the asterisk to import all names from a module, since they can't detect when names are left undefined -- asterisks are greedy and will eat all names!

If one avoids the asterik and attempts to import explicitly, like in `from fontTools.misc.py23 import basestring`, the problem then is that, if `py23` does not re-define the name -- e.g. under python2 `basestring` or `unicode` are built-ins -- then the import statement raises `ImportError`.

The same happens for the `unichr` function on a "wide" Python 2 build (i.e. on in which `sys.maxunicode == 0x10FFFF`).

Now, to work around this, we need to re-assign those built-ins to their very same names. This may look silly, but at least it works.