### PR TITLE
Fix setup.py to install fontTools.subset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
 			"fontTools.misc",
 			"fontTools.pens",
 			"fontTools.ttLib",
+			"fontTools.subset",
 			"fontTools.ttLib.tables",
 		],
 		py_modules = ['sstruct', 'xmlWriter'],


### PR DESCRIPTION
Broken since 29d7edf76f9ca888d120f2018e08e2b337ba7cf8.