### PR TITLE
[V_D_M_X_] sort records by yPelHeight when writing toXML

### DIFF
--- a/Lib/fontTools/ttLib/tables/V_D_M_X_.py
+++ b/Lib/fontTools/ttLib/tables/V_D_M_X_.py
@@ -176,10 +176,10 @@ class table_V_D_M_X_(DefaultTable.DefaultTable):
 			writer.comment("recs=%d, startsz=%d, endsz=%d" %
 							(recs, startsz, endsz))
 			writer.newline()
-			for yPelHeight in group.keys():
-				yMax, yMin = group[yPelHeight]
+			for yPelHeight, (yMax, yMin) in sorted(group.items()):
 				writer.simpletag(
-					"record", yPelHeight=yPelHeight, yMax=yMax, yMin=yMin)
+					"record",
+					[('yPelHeight', yPelHeight), ('yMax', yMax), ('yMin', yMin)])
 				writer.newline()
 			writer.endtag("group")
 			writer.newline()


### PR DESCRIPTION
VDMX groups are dictionaries, hence unsorted. Here I normalize the XML output by sorting them by key (yPelHeight), and also use tuples instead of keyword args so that yPelHeight always appears first in each record.
It's a minor change that won't break the previous API.