### PR TITLE
_g_l_y_f: expand glyphs inside `compile` if recalcBBoxes==True

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -313,6 +313,7 @@ class Glyph(object):
 			return
 		if not self.data:
 			# empty char
+			del self.data
 			self.numberOfContours = 0
 			return
 		dummy, data = sstruct.unpack2(glyphHeaderFormat, self.data, self)
@@ -329,7 +330,11 @@ class Glyph(object):
 
 	def compile(self, glyfTable, recalcBBoxes=True):
 		if hasattr(self, "data"):
-			return self.data
+			if recalcBBoxes:
+				# must unpack glyph in order to recalculate bounding box
+				self.expand(glyfTable)
+			else:
+				return self.data
 		if self.numberOfContours == 0:
 			return ""
 		if recalcBBoxes:


### PR DESCRIPTION
Fixes https://github.com/behdad/fonttools/issues/410.

Also, deletes empty `self.data` lingering around after decompile.
cf. https://github.com/behdad/fonttools/commit/ecbe8f2c37021605672af3c9d4f6b0f6e73df592#commitcomment-14464893