### PR TITLE
ttx: pad tags with space if length is less than 4

### DIFF
--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -156,7 +156,7 @@ class Options(object):
 				self.listTables = True
 			elif option == "-t":
 				# pad with space if table tag length is less than 4
-				value += " " * (4 - len(value))
+				value = value.ljust(4)
 				self.onlyTables.append(value)
 			elif option == "-x":
 				self.skipTables.append(value)

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -155,6 +155,8 @@ class Options(object):
 			elif option == "-l":
 				self.listTables = True
 			elif option == "-t":
+				# pad with space if table tag length is less than 4
+				value += " " * (4 - len(value))
 				self.onlyTables.append(value)
 			elif option == "-x":
 				self.skipTables.append(value)


### PR DESCRIPTION
so that you don't need to do `-t "CFF "` anymore.

Fixes https://github.com/behdad/fonttools/issues/265