### PR TITLE
add Appveyor support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,6 +59,8 @@ install:
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -vr requirements.txt"
 
+build: false
+
 test_script:
   - "SET PATH=C:\\msys64\\usr\\bin;%PATH%"
   # 'run-test.sh' interprets $PYTHON as the executable name

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,74 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C run_with_env.cmd"
+    # links to python-appveyor-demo's scripts by Olivier Grisel's (@ogrisel): 
+    RUN_WITH_ENV_CMD_URL: "https://raw.githubusercontent.com/ogrisel/python-appveyor-demo/master/appveyor/run_with_env.cmd"
+    INSTALL_PS1_URL: "https://raw.githubusercontent.com/ogrisel/python-appveyor-demo/master/appveyor/install.ps1"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+
+install:
+  # download 'run_with_env.cmd' script that configures environment variables for the
+  # MSVC compiler and Windows SDK versions.
+  - "appveyor DownloadFile %RUN_WITH_ENV_CMD_URL%"
+
+  # download 'install.ps1' to install Python (official .msi of http://python.org) and 
+  # pip when not already installed
+  - "appveyor DownloadFile %INSTALL_PS1_URL%"
+  - ps: if (-not(Test-Path($env:PYTHON))) { & install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # upgrade pip to avoid out-of-date warnings
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "%CMD_IN_ENV% pip install -vr requirements.txt"
+
+test_script:
+  - "SET PATH=C:\\msys64\\usr\\bin;%PATH%"
+  # 'run-test.sh' interprets $PYTHON as the executable name
+  - "SET PYTHON=python"
+  - "bash run-tests.sh"
+
+after_test:
+  # if tests are successful, create packages for the project
+  - "%CMD_IN_ENV% python setup.py sdist --formats=zip"
+
+artifacts:
+  # archive the generated packages in the ci.appveyor.com build report
+  - path: dist\*

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# exit if any subcommand return non-zero status
+set -e
+
 # Choose python version
 if test "x$1" = x-3; then
 	PYTHON=python3


### PR DESCRIPTION
Currently we only run tests on Ubuntu Linux via Travis.
I'd like to also run the tests on Windows Python, since there are sometimes differences in the implementations (e.g. newlines, binary vs text, etc.).
This adds a `.appveyor.yml` to set up the Appveyor CI.
I'm not sure if I can enable the project myself or @behdad needs to do it on his side.

Anyway, here's the link to the current build running from my fork:
https://ci.appveyor.com/project/anthrotype/fonttools/build/1.0.29

(fingers crossed)