### PR TITLE
Travis multi-os setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
       env: TOXENV=pypy
     - language: generic
       os: osx
+      # the default 'osx' on Travis is 10.9 Mavericks, with Python 2.7.5
+      env: TOXENV=py27
+    - language: generic
+      os: osx
+      # this is to test on 10.11 El Capitan which comes with Python 2.7.10
+      osx_image: osx10.11
       env: TOXENV=py27
     - language: generic
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - ./.travis/install.sh
 
 script:
-  - tox
+  - ./.travis/run.sh
 
 notifications:
   irc: "irc.freenode.org##fonts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,41 @@
 sudo: false
+
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
-#  - "pypy3" # Disable pypy3 until Travis updates it to >= 3.3
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: pypy
+      env: TOXENV=pypy
+    - language: generic
+      os: osx
+      env: TOXENV=py27
+    - language: generic
+      os: osx
+      env: TOXENV=py33
+    - language: generic
+      os: osx
+      env: TOXENV=py34
+    - language: generic
+      os: osx
+      env: TOXENV=py35
+    - language: generic
+      os: osx
+      env: TOXENV=pypy
+
 install:
-  - pip install -vr requirements.txt
-  - make install
+  - ./.travis/install.sh
+
 script:
-  - make check
+  - tox
+
 notifications:
   irc: "irc.freenode.org##fonts"
   email: fonttools@googlegroups.com

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew install pyenv
+    brew outdated pyenv || brew upgrade pyenv
+
+    if which -s pyenv; then
+        eval "$(pyenv init -)"
+    fi
+
+    case "${TOXENV}" in
+        py27)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py33)
+            pyenv install 3.3.6
+            pyenv global 3.3.6
+            ;;
+        py34)
+            pyenv install 3.4.3
+            pyenv global 3.4.3
+            ;;
+        py35)
+            pyenv install 3.5.0
+            pyenv global 3.5.0
+            ;;
+        pypy)
+            pyenv install pypy-4.0.1
+            pyenv global pypy-4.0.1
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install --user virtualenv
+else
+    # install pyenv to get latest pypy
+    if [[ "${TOXENV}" == "pypy" ]]; then
+        git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+        PYENV_ROOT="$HOME/.pyenv"
+        PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+        pyenv install pypy-4.0.1
+        pyenv global pypy-4.0.1
+    fi
+    pip install virtualenv
+fi
+
+python -m virtualenv ~/.venv
+source ~/.venv/bin/activate
+pip install tox

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,7 +5,7 @@ set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
-    brew install pyenv
+    (brew list | grep -q 'pyenv') || brew install pyenv
     brew outdated pyenv || brew upgrade pyenv
 
     if which -s pyenv; then

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    eval "$(pyenv init -)"
+else
+    if [[ "${TOXENV}" == "pypy" ]]; then
+        PYENV_ROOT="$HOME/.pyenv"
+        PATH="$PYENV_ROOT/bin:$PATH"
+        eval "$(pyenv init -)"
+    fi
+fi
+source ~/.venv/bin/activate
+tox

--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -8,15 +8,15 @@ Example interactive session:
 
 Python 1.5.2c1 (#43, Mar  9 1999, 13:06:43)  [CW PPC w/GUSI w/MSL]
 Copyright 1991-1995 Stichting Mathematisch Centrum, Amsterdam
->>> from fontTools import ttLib
->>> tt = ttLib.TTFont("afont.ttf")
->>> tt['maxp'].numGlyphs
+>> from fontTools import ttLib
+>> tt = ttLib.TTFont("afont.ttf")
+>> tt['maxp'].numGlyphs
 242
->>> tt['OS/2'].achVendID
+>> tt['OS/2'].achVendID
 'B&H\000'
->>> tt['head'].unitsPerEm
+>> tt['head'].unitsPerEm
 2048
->>> tt.saveXML("afont.ttx")
+>> tt.saveXML("afont.ttx")
 Dumping 'LTSH' table...
 Dumping 'OS/2' table...
 Dumping 'VDMX' table...
@@ -33,11 +33,11 @@ Dumping 'maxp' table...
 Dumping 'name' table...
 Dumping 'post' table...
 Dumping 'prep' table...
->>> tt2 = ttLib.TTFont()
->>> tt2.importXML("afont.ttx")
->>> tt2['maxp'].numGlyphs
+>> tt2 = ttLib.TTFont()
+>> tt2.importXML("afont.ttx")
+>> tt2['maxp'].numGlyphs
 242
->>>
+>>
 
 """
 

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
+from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27, pypy, py33, py34, py35
+
+[testenv]
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    py.test Lib/fontTools
+
+[pytest]
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a
+    # run doctests in all .py modules
+    --doctest-modules
+    # py.test raises ImportError with inspect.py (requires pygtk) and with
+    # reportLabPen.py (reportlab). They don't have doctests, it's OK to skip.
+    --doctest-ignore-import-errors


### PR DESCRIPTION
This is to enable testing on OS X Python with Travis, alongside Linux.

Unfortunately the Python runtime is not yet available on Travis for OS X environment (cf. https://github.com/travis-ci/travis-ci/issues/2312).

Therefore, I had to use [pyenv](https://github.com/yyuu/pyenv) to downlaod and install the various Pythons (3.3, 3.4, 3.5 and pypy) which are not already installed on OS X. For 2.7 I test both the default system Python 2.7.5 that comes with OS X 10.9 (the default Travis OS X machine), and the Python 2.7.10 which is pre-installed on El Capitan.

For setting up the virtual environment, downloading the requirements and running the tests I use [tox](https://tox.readthedocs.org/en/latest/). This integrates nicely with [pytest](https://pytest.org/), which in turn can discover and run any doctests or unittests, besides its own kind of tests.

The nice thing about using tox in combination with pytest is that, if one has all the various Pythons installed locally on one's machine, then one can simply type `tox` and have the test suite run on all of them, each in its own isolated virtual environment. That's what the Python cool kids are now using, so we can't miss out!

BTW, thanks to setting this up, I found an issue with `struct` in the old Python 2.7.5 (Mavericks' default), which raises when format strings are unicodes (e.g. when one does `from __future__ import unicode_literals`). I fixed that in the trak table module by simply not importing unicode_literals, as it's not really needed there.

One more reasons to test as many python environments as we can :)

Oh, the build passes on my fork: https://travis-ci.org/anthrotype/fonttools/builds/96480740
