### PR TITLE
Remove obsolete code - 'xml.parsers.expat' is part of Python's stdlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,6 @@ except ImportError:
 else:
 	distutils_scripts = []
 
-try:
-	import xml.parsers.expat
-except ImportError:
-	print("*** Warning: FontTools needs PyXML, see:")
-	print("        http://sourceforge.net/projects/pyxml/")
-
 
 # Force distutils to use py_compile.compile() function with 'doraise' argument
 # set to True, in order to raise an exception on compilation errors


### PR DESCRIPTION
The 'xml.parsers.expat' module has been a part of Python's Standard Library since version 2.0. Link: https://docs.python.org/2/library/pyexpat.html#module-xml.parsers.expat . FontTools requires Python 2.7, or Python 3.3 or later. Checking for the existence of this module is not necessary anymore.