### PR TITLE
timeTools: define platform-independent 'asctime' function

### DIFF
--- a/Lib/fontTools/misc/timeTools.py
+++ b/Lib/fontTools/misc/timeTools.py
@@ -9,8 +9,39 @@ import calendar
 
 epoch_diff = calendar.timegm((1904, 1, 1, 0, 0, 0, 0, 0, 0))
 
+DAYNAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+MONTHNAMES = [None, "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+			  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def asctime(t=None):
+	"""
+	Convert a tuple or struct_time representing a time as returned by gmtime()
+	or localtime() to a 24-character string of the following form:
+
+	>>> asctime(time.gmtime(0))
+	'Thu Jan  1 00:00:00 1970'
+
+	If t is not provided, the current time as returned by localtime() is used.
+	Locale information is not used by asctime().
+
+	This is meant to normalise the output of the built-in time.asctime() across
+	different platforms and Python versions.
+	In Python 3.x, the day of the month is right-justified, whereas on Windows
+	Python 2.7 it is padded with zeros.
+
+	See https://github.com/behdad/fonttools/issues/455
+	"""
+	if t is None:
+		t = time.localtime()
+	s = "%s %s %2s %s" % (
+		DAYNAMES[t.tm_wday], MONTHNAMES[t.tm_mon], t.tm_mday,
+		time.strftime("%H:%M:%S %Y", t))
+	return s
+
+
 def timestampToString(value):
-	return time.asctime(time.gmtime(max(0, value + epoch_diff)))
+	return asctime(time.gmtime(max(0, value + epoch_diff)))
 
 def timestampFromString(value):
 	return calendar.timegm(time.strptime(value)) - epoch_diff
@@ -20,3 +51,9 @@ def timestampNow():
 
 def timestampSinceEpoch(value):
 	return int(value - epoch_diff)
+
+
+if __name__ == "__main__":
+	import sys
+	import doctest
+	sys.exit(doctest.testmod().failed)


### PR DESCRIPTION
This is meant to normalise the output of the built-in `time.asctime()` across different platforms and Python versions.

In Python 3.x, the day of the month is right-justified, whereas on Windows Python 2.7 it is padded with zeros.
The reason is that, in the `timemodule.c` on CPython 2.x, they invoke the built-in C runtime's `asctime` function (which is implemented differently on Unix and Windows). In CPython 3.x they have defined a custom `_asctime` function to work around this.

Note that we cannot use `time.strftime` to format the time tuple, since that returns a locale dependent string, wheres here we are trying to replicate the default `asctime` behaviour, which is locale independent.

Fixes https://github.com/behdad/fonttools/issues/455