### PR TITLE
Added otlLib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
 			"fontTools.ttLib",
 			"fontTools.t1Lib",
 			"fontTools.subset",
+			"fontTools.otlLib",
 			"fontTools.ttLib.tables",
 		],
 		py_modules = ['sstruct', 'xmlWriter'],


### PR DESCRIPTION
Without otlLib in the setup file it gives the error 
```python
ImportError: No module named otlLib
```
when using defcon library.