### PR TITLE
[py23] add wrapper for io.open

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -156,6 +156,85 @@ else:
 		return tobytes(joiner).join(tobytes(item) for item in iterable)
 
 
+import os
+import io as _io
+
+try:
+	from msvcrt import setmode as _setmode
+except ImportError:
+	_setmode = None  # only available on the Windows platform
+
+
+def open(file, mode='r', buffering=-1, encoding=None, errors=None,
+		 newline=None, closefd=True, opener=None):
+	""" Wrapper around `io.open` that bridges the differences between Python 2
+	and Python 3's built-in `open` functions. In Python 2, `io.open` is a
+	backport of Python 3's `open`, whereas in Python 3, it is an alias of the
+	built-in `open` function.
+
+	One difference is that the 'opener' keyword argument is only supported in
+	Python 3. Here we pass the value of 'opener' only when it is not None.
+	This causes Python 2 to raise TypeError, complaining about the number of 
+	expected arguments, so it must be avoided if py2 or py2-3 contexts.
+
+	Another difference between 2 and 3, this time on Windows, has to do with
+	opening files by name or by file descriptor.
+
+	On the Windows C runtime, the 'O_BINARY' flag is defined which disables
+	the newlines translation ('\r\n' <=> '\n') when reading/writing files.
+	On both Python 2 and 3 this flag is always set when opening files by name.
+	This way, the newlines translation at the MSVCRT level doesn't interfere
+	with the Python io module's own newlines translation.
+
+	However, when opening files via fd, on Python 2 the fd is simply copied,
+	regardless of whether it has the 'O_BINARY' flag set or not.
+	This becomes a problem in the case of stdout, stdin, and stderr, because on
+	Windows these are opened in text mode by default (ie. don't have the
+	O_BINARY flag set).
+
+	On Python 3, this issue has been fixed, and all fds are now opened in
+	binary mode on Windows, including standard streams. Similarly here, I use
+	the `_setmode` function to ensure that integer file descriptors are
+	O_BINARY'ed before I pass them on to io.open.
+
+	For more info, see: https://bugs.python.org/issue10841
+	"""
+	if isinstance(file, int):
+		# the 'file' argument is an integer file descriptor
+		fd = file
+		if fd < 0:
+			raise ValueError('negative file descriptor')
+		if _setmode:
+			# `_setmode` function sets the line-end translation and returns the
+			# value of the previous mode. AFAIK there's no `_getmode`, so to
+			# check if the previous mode already had the bit set, I fist need
+			# to duplicate the file descriptor, set the binary flag on the copy
+			# and check the returned value.
+			fdcopy = os.dup(fd)
+			current_mode = _setmode(fdcopy, os.O_BINARY)
+			if not (current_mode & os.O_BINARY):
+				# the binary mode was not set: use the file descriptor's copy
+				file = fdcopy
+				if closefd:
+					# close the original file descriptor
+					os.close(fd)
+				else:
+					# ensure the copy is closed when the file object is closed
+					closefd = True
+			else:
+				# original file descriptor already had binary flag, close copy
+				os.close(fdcopy)
+
+	if opener is not None:
+		# "opener" is not supported on Python 2, use it at your own risk!
+		return _io.open(
+			file, mode, buffering, encoding, errors, newline, closefd,
+			opener=opener)
+	else:
+		return _io.open(
+			file, mode, buffering, encoding, errors, newline, closefd)
+
+
 if __name__ == "__main__":
 	import doctest, sys
 	sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -1,0 +1,66 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import tobytes
+from fontTools.misc.textTools import deHexStr
+import filecmp
+import tempfile
+from subprocess import check_call
+import sys
+import os
+import unittest
+
+
+PIPE_SCRIPT = """\
+import sys
+binary_stdin = open(sys.stdin.fileno(), mode='rb', closefd=False)
+binary_stdout = open(sys.stdout.fileno(), mode='wb', closefd=False)
+binary_stdout.write(binary_stdin.read())
+"""
+
+# the string contains a mix of line endings, plus the Win "EOF" charater (0x1A)
+# 'hello\rworld\r\n\x1a\r\n'
+TEST_BIN_DATA = deHexStr(
+	"68 65 6c 6c 6f 0d 77 6f 72 6c 64 0d 0a 1a 0d 0a"
+)
+
+class OpenFuncWrapperTest(unittest.TestCase):
+
+	@staticmethod
+	def make_temp(data):
+		with tempfile.NamedTemporaryFile(delete=False) as f:
+			f.write(tobytes(data))
+		return f.name
+
+	def diff_piped(self, data, import_statement):
+		script = self.make_temp("\n".join([import_statement, PIPE_SCRIPT]))
+		datafile = self.make_temp(data)
+		try:
+			with open(datafile, 'rb') as infile, \
+					tempfile.NamedTemporaryFile(delete=False) as outfile:
+				check_call(
+					[sys.executable, script], stdin=infile, stdout=outfile)
+			result = not filecmp.cmp(infile.name, outfile.name, shallow=False)
+		finally:
+			os.remove(script)
+			os.remove(datafile)
+			os.remove(outfile.name)
+		return result
+
+	def test_binary_pipe_py23_open_wrapper(self):
+		if self.diff_piped(
+				TEST_BIN_DATA, "from fontTools.misc.py23 import open"):
+			self.fail("Input and output data differ!")
+
+	def test_binary_pipe_built_in_io_open(self):
+		if sys.version_info.major < 3 and sys.platform == 'win32':
+			# On Windows Python 2.x, the piped input and output data are
+			# expected to be different when using io.open, because of issue
+			# https://bugs.python.org/issue10841.
+			expected = True
+		else:
+			expected = False
+		result = self.diff_piped(TEST_BIN_DATA, "from io import open")
+		self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,7 +19,11 @@ echo
 # Setup environment
 DIR=`dirname "$0"`
 cd "$DIR/Lib"
-PYTHONPATH=".:$PYTHONPATH"
+if [ "x$PYTHONPATH" != "x" ]; then
+	PYTHONPATH=".:$PYTHONPATH"
+else
+	PYTHONPATH="."
+fi
 export PYTHONPATH
 
 # Find tests


### PR DESCRIPTION
In this patch, I define an `open` function in py23.py which wraps around the `io.open` function.

In Python 2, `io.open` is a backport of Python 3's `open`. This is much better than the built-in python2 `open`. (In Python 3, `io.open` is simply an alias of its built-in `open` function).

Using `io.open` will enable us, for example, to use the `encoding` argument without needing to call `codecs.open`, or re-opening the standard I/O streams in binary mode, so that we can pipe binary data through them.

```python
binary_stdin = open(sys.stdin.fileno(), mode='rb', closefd=False)
binary_stdout = open(sys.stdout.fileno(), mode='wb', closefd=False)
```

The problem is, the statement above would work fine with the vanilla `io.open` function on Python 3, as well as on Python 2 on the "unix" platform. It fails however on "win32" Python 2 because of an issue in the way Python 2 interacts with the Microsoft C runtime (https://bugs.python.org/issue10841).

This `py23.open` wrapper fixes this issue, and enables binary stdio on both Python 2 and 3 and on all platforms, Windows included!