### PR TITLE
[psCharStrings] use fixedToFloat to use the shortest decimal representation

### DIFF
--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -4,6 +4,7 @@ CFF dictionary data and Type1/Type2 CharStrings.
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import fixedToFloat
 import struct
 import logging
 
@@ -42,7 +43,7 @@ def read_longInt(self, b0, data, index):
 
 def read_fixed1616(self, b0, data, index):
 	value, = struct.unpack(">l", data[index:index+4])
-	return value / 65536, index+4
+	return fixedToFloat(value, precisionBits=16), index+4
 
 def read_reserved(self, b0, data, index):
 	assert NotImplementedError


### PR DESCRIPTION
Fixes https://github.com/behdad/fonttools/issues/492

using @HinTak's example:
```
107 53.400390625 166.19900512695312 hstem
174.60000610351562 163.80099487304688 vstem
338.3999938964844 142.8000030517578 rmoveto
0 21.600006103515625 -6.29998779296875 18.20001220703125 -12.600006103515625 14.79998779296875 -12.600006103515625 14.800003051757812 -18.100006103515625 7.4000091552734375 -23.5999755859375 0 -28.400009155273438 0 -22.199996948242188 -8.70001220703125 -16 -17.399993896484375 -16 -17.399993896484375 -8 -20.300003051757812 0 -23.199996948242188 0 -21.600006103515625 6.5 -18.599609375 13 -15.6005859375 13 -15.599609375 18.29998779296875 -7.7998046875 23.600006103515625 0 rrcurveto
28 0 21.899993896484375 9 15.800018310546875 18 15.79998779296875 18 7.899993896484375 20.799606323242188 0 23.600006103515625 rrcurveto
endchar
```

it will now be written as:
```
107 53.40039 166.199 hstem
174.6 163.801 vstem
338.4 142.8 rmoveto
0 21.6 -6.29999 18.20001 -12.6 14.79999 -12.6 14.8 -18.1 7.40001 -23.59998 0 -28.40001 0 -22.2 -8.70001 -16 -17.4 -16 -17.4 -8 -20.3 0 -23.2 0 -21.6 6.5 -18.59961 13 -15.60059 13 -15.59961 18.29999 -7.7998 23.6 0 rrcurveto
28 0 21.9 9 15.80002 18 15.79999 18 7.9 20.7996 0 23.6 rrcurveto
endchar
```

without any loss of precision, nor roundtripping differences in the binary table.