### PR TITLE
Replace one last call to debug() in mtiLib

### DIFF
--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -858,7 +858,7 @@ def parseGSUBGPOS(lines, font, tableTag):
 	while lines.peek() is not None:
 		typ = lines.peek()[0].lower()
 		if typ not in fields:
-			debug ('Skipping', lines.peek())
+			log.debug('Skipping', lines.peek())
 			next(lines)
 			continue
 		attr,parser = fields[typ]


### PR DESCRIPTION
I think this was mistakenly left out of
b62f5509524a49101ab6f211f1c3b63458f52f5e