### PR TITLE
Suuport cubic curves in TTGlyphPen

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -8,6 +8,11 @@ from fontTools.ttLib.tables import ttProgram
 from fontTools.ttLib.tables._g_l_y_f import Glyph
 from fontTools.ttLib.tables._g_l_y_f import GlyphComponent
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
+try:
+    from cu2qu import curve_to_quadratic
+except ImportError:
+    curve_to_quadratic = None
+from fontTools.pens.basePen import decomposeSuperBezierSegment
 
 
 __all__ = ["TTGlyphPen", "C2QGlyphPen"]
@@ -116,9 +121,12 @@ class TTGlyphPen(AbstractPen):
 
         return glyph
 
+
 class C2QGlyphPen(TTGlyphPen):
 
     def __init__(self, glyphSet, maxError):
+        if curve_to_quadratic is None:
+            raise ImportError("No module named 'cu2qu'")
         super(C2QGlyphPen, self).__init__(glyphSet)
         self.maxError = maxError
         self.last = None
@@ -131,11 +139,31 @@ class C2QGlyphPen(TTGlyphPen):
         super(C2QGlyphPen, self).moveTo(pt)
         self.last = pt
 
+    def qCurveTo(self, *points):
+        super(C2QGlyphPen, self).qCurveTo(*points)
+        self.last = points[-1]
+
+    def _curveToQuadratic(self, pt1, pt2, pt3):
+        assert self.last is not None
+        curve = (self.last, pt1, pt2, pt3)
+        quadratic, err = curve_to_quadratic(curve, self.maxError)
+        self.qCurveTo(*quadratic[1:])
+
     def curveTo(self, *points):
-        from cu2qu import curve_to_quadratic, curves_to_quadratic
-        from fontTools.pens.basePen import decomposeSuperBezierSegment
-        for segment in decomposeSuperBezierSegment(points):
-            curve = (self.last, segment[0], segment[1], segment[2])
-            quadratic, err = curve_to_quadratic(curve, self.maxError)
-            self.last = segment[2]
-            self.qCurveTo(*quadratic)
+        # 'n' is the number of control points
+        n = len(points) - 1
+        assert n >= 0
+        if n == 2:
+            # this is the most common case, so we special-case it
+            self._curveToQuadratic(*points)
+        elif n > 2:
+            for segment in decomposeSuperBezierSegment(points):
+                self._curveToQuadratic(*segment)
+        elif n == 1:
+            self.qCurveTo(*points)
+        elif n == 0:
+            self.lineTo(points[0])
+
+    def closePath(self):
+        super(C2QGlyphPen, self).closePath()
+        self.last = None


### PR DESCRIPTION
Using https://github.com/googlei18n/cu2qu to convert cubic to quadratic curves. This can be then used to convert CFF charstrings to glyf glyphs.

I kept the commits as this evolved with @anthrotype help, but I guess the commits should be squashed before merging.