### PR TITLE
[ttGlyphPen] only add empty ttProgram to simple glyphs, not to composites

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -110,8 +110,7 @@ class TTGlyphPen(AbstractPen):
             glyph.numberOfContours = -1
         else:
             glyph.numberOfContours = len(glyph.endPtsOfContours)
-
-        glyph.program = ttProgram.Program()
-        glyph.program.fromBytecode(b"")
+            glyph.program = ttProgram.Program()
+            glyph.program.fromBytecode(b"")
 
         return glyph


### PR DESCRIPTION
Unlike simple glyphs (i.e. with contours) which must always have `instructionLength` field, the latter is optional in composite glyphs and depends on whether `WE_HAVE_INSTR` flag is set:
https://www.microsoft.com/typography/otspec/glyf.htm

In the previous code, the `TTGlyphPen` was adding an empty `program` attribute to all new glyphs, including composites, whereas it should only do it for simple glyphs.

For example, if you take Roboto-Regular.ttf from here:
https://github.com/google/roboto/releases/tag/v2.129

The font (unhinted) was compiled using the ttGlyphPen. It has 1434 composite glyphs. For each of them, a USHORT value for the number of instructions (0) is written, so the binary ttf is 2.868 KB greater than
what it should be.

/cc @jamesgk 