### PR TITLE
test for NotImplemented in __ne__; add __eq__ and __ne__ to ttProgram.Program

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen_test.py
+++ b/Lib/fontTools/pens/ttGlyphPen_test.py
@@ -68,7 +68,6 @@ class TTGlyphPenTest(unittest.TestCase):
         pen.endPath()
         endPathGlyph = pen.glyph()
 
-        endPathGlyph.program = closePathGlyph.program
         self.assertEqual(closePathGlyph, endPathGlyph)
 
     def test_glyph_errorOnUnendedContour(self):
@@ -105,7 +104,6 @@ class TTGlyphPenTest(unittest.TestCase):
         pen.closePath()
         plainGlyph = pen.glyph()
 
-        plainGlyph.program = compositeGlyph.program
         self.assertEqual(plainGlyph, compositeGlyph)
 
 

--- a/Lib/fontTools/ttLib/tables/DefaultTable.py
+++ b/Lib/fontTools/ttLib/tables/DefaultTable.py
@@ -39,9 +39,11 @@ class DefaultTable(object):
 	def __repr__(self):
 		return "<'%s' table at %x>" % (self.tableTag, id(self))
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
 		return self.__dict__ == other.__dict__
+
+	def __ne__(self, other):
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -979,13 +979,14 @@ class Glyph(object):
 					cFlags = cFlags[nextOnCurve:]
 			pen.closePath()
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
 		return self.__dict__ == other.__dict__
 
+	def __ne__(self, other):
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
 
 class GlyphComponent(object):
 
@@ -1141,12 +1142,14 @@ class GlyphComponent(object):
 			self.transform = [[scale, 0], [0, scale]]
 		self.flags = safeEval(attrs["flags"])
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
 		return self.__dict__ == other.__dict__
+
+	def __ne__(self, other):
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
 
 class GlyphCoordinates(object):
 
@@ -1261,13 +1264,14 @@ class GlyphCoordinates(object):
 			py = x * t[0][1] + y * t[1][1]
 			self[i] = (px, py)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
 		return self._a == other._a
 
+	def __ne__(self, other):
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
 
 def reprflag(flag):
 	bin = ""

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -305,11 +305,10 @@ class TrackTableEntry(MutableMapping):
 		return "TrackTableEntry({}, nameIndex={})".format(self._map, self.nameIndex)
 
 	def __eq__(self, other):
-		if (isinstance(other, TrackTableEntry)
-				and self.nameIndex == other.nameIndex
-				and dict(self) == dict(other)):
-			return True
-		return False
+		if not isinstance(other, self.__class__):
+			return NotImplemented
+		return self.nameIndex == other.nameIndex and dict(self) == dict(other)
 
 	def __ne__(self, other):
-		return not self.__eq__(other)
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -345,7 +345,9 @@ class OTTableWriter(object):
 		return hash(self.items)
 
 	def __ne__(self, other):
-		return not self.__eq__(other)
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
+
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
@@ -754,7 +756,9 @@ class BaseTable(object):
 			setattr(self, conv.name, value)
 
 	def __ne__(self, other):
-		return not self.__eq__(other)
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
+
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented
@@ -933,7 +937,9 @@ class ValueRecord(object):
 			setattr(self, name, value)
 
 	def __ne__(self, other):
-		return not self.__eq__(other)
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
+
 	def __eq__(self, other):
 		if type(self) != type(other):
 			return NotImplemented

--- a/Lib/fontTools/ttLib/tables/ttProgram.py
+++ b/Lib/fontTools/ttLib/tables/ttProgram.py
@@ -496,6 +496,15 @@ class Program(object):
 
 	__nonzero__ = __bool__
 
+	def __eq__(self, other):
+		if type(self) != type(other):
+			return NotImplemented
+		return self.__dict__ == other.__dict__
+
+	def __ne__(self, other):
+		result = self.__eq__(other)
+		return result if result is NotImplemented else not result
+
 
 def _test():
 	"""


### PR DESCRIPTION
`_g_l_y_f.Glyph` objects have handy `__eq__` and `__ne__` methods. However their `program` attribute did not, so it was using `object`'s default `id(self) == id(other)`, which returns False even when the content of two Program instances is the same.
So I added that.

While doing this I noticed that there are other classes in fonttools which similarly implement `__eq__` and `__ne__`, but they have a problem in that, `__ne__` is defined as `not self.__eq__(other)`, but when the `type(self) != type(other)`, then `__eq__` will (correctly) return `NotImplemented`, and thus `__ne__` will return `not NotImplemeted`, which is always False no matter what.

This can lead to illogic results like:

```python
>>> from fontTools.ttLib.tables.DefaultTable import DefaultTable
>>> t = DefaultTable('test')
>>> t == 0
False
>>> t != 0
False
```

The latter of course should return True.
So I changed all `__ne__` to first check if `__eq__` returned `NotImplemeted`, and if so return that as well. This will delegate the comparison to the superclass (`object`) -- which, in the example above, will return True.