### PR TITLE
Fix handling of default lookupflag

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -338,6 +338,8 @@ class Builder(object):
         self.language_systems = self.get_default_language_systems_()
         self.cur_lookup_ = None
         self.cur_feature_name_ = name
+        self.lookupflag_ = 0
+        self.lookupflag_markFilterSet_ = None
         if name == "aalt":
             self.aalt_location_ = location
 
@@ -346,6 +348,8 @@ class Builder(object):
         self.cur_feature_name_ = None
         self.language_systems = None
         self.cur_lookup_ = None
+        self.lookupflag_ = 0
+        self.lookupflag_markFilterSet_ = None
 
     def start_lookup_block(self, location, name):
         if name in self.named_lookups_:
@@ -359,11 +363,15 @@ class Builder(object):
         self.cur_lookup_name_ = name
         self.named_lookups_[name] = None
         self.cur_lookup_ = None
+        self.lookupflag_ = 0
+        self.lookupflag_markFilterSet_ = None
 
     def end_lookup_block(self):
         assert self.cur_lookup_name_ is not None
         self.cur_lookup_name_ = None
         self.cur_lookup_ = None
+        self.lookupflag_ = 0
+        self.lookupflag_markFilterSet_ = None
 
     def add_lookup_call(self, lookup_name):
         assert lookup_name in self.named_lookups_, lookup_name

--- a/Lib/fontTools/feaLib/testdata/lookupflag.fea
+++ b/Lib/fontTools/feaLib/testdata/lookupflag.fea
@@ -63,6 +63,9 @@ lookup K {
     pos K 1;
 } K;
 
+lookup L {
+    pos L 1;
+} L;
 
 feature test {
     lookup A;
@@ -76,4 +79,5 @@ feature test {
     lookup I;
     lookup J;
     lookup K;
+    lookup L;
 } test;

--- a/Lib/fontTools/feaLib/testdata/lookupflag.ttx
+++ b/Lib/fontTools/feaLib/testdata/lookupflag.ttx
@@ -53,7 +53,7 @@
       <FeatureRecord index="0">
         <FeatureTag value="test"/>
         <Feature>
-          <!-- LookupCount=11 -->
+          <!-- LookupCount=12 -->
           <LookupListIndex index="0" value="0"/>
           <LookupListIndex index="1" value="1"/>
           <LookupListIndex index="2" value="2"/>
@@ -65,11 +65,12 @@
           <LookupListIndex index="8" value="8"/>
           <LookupListIndex index="9" value="9"/>
           <LookupListIndex index="10" value="10"/>
+          <LookupListIndex index="11" value="11"/>
         </Feature>
       </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=11 -->
+      <!-- LookupCount=12 -->
       <Lookup index="0">
         <!-- LookupType=1 -->
         <LookupFlag value="1"/>
@@ -204,6 +205,18 @@
           <Value XAdvance="1"/>
         </SinglePos>
         <MarkFilteringSet value="0"/>
+      </Lookup>
+      <Lookup index="11">
+        <!-- LookupType=1 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="L"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="1"/>
+        </SinglePos>
       </Lookup>
     </LookupList>
   </GPOS>


### PR DESCRIPTION
According to the spec:
> The lookupflag attribute defaults to 0 at the start of a feature
> block.
>
> The lookupflag attribute stays the same until explicitly changed, until
> a lookup reference statement is encountered that changes it, until the
> script is changed, or until the end of the feature.

This is an attempt to fix this by resetting the lookupflag at the start
and end of feature/lookup blacks. I’m not sure if resetting it in lookup
blocks is correct (my reading of the spec suggests it is not), but one
needs to test this against makeotf and see how it behaves here.