### PR TITLE
[feaLib] Fix typo in testdata/spec9e.*

### DIFF
--- a/Lib/fontTools/feaLib/testdata/spec9e.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9e.fea
@@ -1,4 +1,4 @@
 table name {
   nameid 9 "Joachim M\00fcller-Lanc\00e9";    # Windows (Unicode)
-  nameid 9 1 "Joachim Mu\9fller-Lanc\8e";     # Macintosh (Mac Roman)
+  nameid 9 1 "Joachim M\9fller-Lanc\8e";      # Macintosh (Mac Roman)
 } name;

--- a/Lib/fontTools/feaLib/testdata/spec9e.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec9e.ttx
@@ -6,7 +6,7 @@
       Joachim Müller-Lancé
     </namerecord>
     <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Joachim Muüller-Lancé
+      Joachim Müller-Lancé
     </namerecord>
   </name>
 


### PR DESCRIPTION
Feature File Spec itself was fixed in https://github.com/adobe-type-tools/afdko/pull/110