### PR TITLE
[fealib] ignore nameIDs 1-6 in parser and issue a warning

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -4,8 +4,12 @@ from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lexer import Lexer, IncludingLexer
 from fontTools.misc.py23 import *
 import fontTools.feaLib.ast as ast
+import logging
 import os
 import re
+
+
+log = logging.getLogger(__name__)
 
 
 class Parser(object):
@@ -788,7 +792,9 @@ class Parser(object):
             raise FeatureLibError("Expected name id < 255",
                                   self.cur_token_location_)
         if 1 <= nameID <= 6:
-            # TODO: issue a warning
+            log.warning("Name id %d cannot be set from the feature file. "
+                        "Ignoring record" % nameID)
+            self.parse_name_()  # skip to the next record
             return None
 
         platformID, platEncID, langID, string = self.parse_name_()

--- a/Lib/fontTools/feaLib/testdata/name.fea
+++ b/Lib/fontTools/feaLib/testdata/name.fea
@@ -1,4 +1,10 @@
 table name {
+  nameid 1 "Ignored-1";
+  nameid 2 "Ignored-2";
+  nameid 3 "Ignored-3";
+  nameid 4 "Ignored-4";
+  nameid 5 "Ignored-5";
+  nameid 6 "Ignored-6";
   nameid 7 3 "Test7";
   nameid 8 1 "Test8";
   nameid 9 3 1 0x0409 "Test9";


### PR DESCRIPTION
this the same as what makeotf currently does for nameIDs between 1 and 6.

http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#9.e

> Note that ids 1-6 (Family, Subfamily, Unique, Full, Version, and FontName) are reserved by the implementation and cannot be overridden; doing so will elicit a warning message and the record will be ignored.

I can see why makeotf would reserve those nameIDs, since they are auto-generated from the FontMenuNameDB file. However, in feaLib we could easily allow users to override those as well, if the spec did not explicitly forbid that...