### PR TITLE
fix Appveyor Python 3.4 64-bit build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,53 +1,68 @@
 environment:
+  global:
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\.appveyor\\with-compiler.cmd"
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
+    - JOB: "2.7.11 32-bit"
+      PYTHON_HOME: "C:\\Python27"
       TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27\\python.exe"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
+    - JOB: "3.4.3 32-bit"
+      PYTHON_HOME: "C:\\Python34"
       TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34\\python.exe"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
+    - JOB: "3.5.1 32-bit"
+      PYTHON_HOME: "C:\\Python35"
       TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35\\python.exe"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
+    - JOB: "2.7.11 64-bit"
+      PYTHON_HOME: "C:\\Python27-x64"
       TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27-x64\\python.exe"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
+    - JOB: "3.4.3 64-bit"
+      PYTHON_HOME: "C:\\Python34-x64"
       TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34-x64\\python.exe"
+      DISTUTILS_USE_SDK: "1"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
+    - JOB: "3.5.1 64-bit"
+      PYTHON_HOME: "C:\\Python35-x64"
       TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35-x64\\python.exe"
 
 install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
   # Prepend Python to the PATH of this build
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\\Scripts;%PATH%"
 
   # check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # upgrade pip to avoid out-of-date warnings
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip --version"
 
   # install the dependencies to run the tests
-  - "pip install -r dev-requirements.txt"
+  - "%WITH_COMPILER% python -m pip install -r dev-requirements.txt"
+ 
 
 build: false
 
 test_script:
-  - "tox"
+  - "%WITH_COMPILER% tox"
 
 notifications:
   - provider: Email

--- a/.appveyor/with-compiler.cmd
+++ b/.appveyor/with-compiler.cmd
@@ -1,0 +1,21 @@
+@echo off
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+
+IF "%DISTUTILS_USE_SDK%"=="1" (
+    ECHO Configuring environment to build with MSVC on a 64bit architecture
+    ECHO Using Windows SDK 7.1
+    "C:\Program Files\Microsoft SDKs\Windows\v7.1\Setup\WindowsSdkVer.exe" -q -version:v7.1
+    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
+    SET MSSdk=1
+    REM Need the following to allow tox to see the SDK compiler
+    SET TOX_TESTENV_PASSENV=DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+) ELSE (
+    ECHO Using default MSVC build environment
+)
+
+CALL %*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest>=2.8
+virtualenv>=15.0
 tox>=2.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27, pypy, py34, py35
+envlist = py27, pypy, py33, py34, py35
 
 [testenv]
 basepython =
     py27: {env:TOXPYTHON:python2.7}
     pypy: {env:TOXPYTHON:pypy}
+    py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,22 @@
 [tox]
-envlist = py27, pypy, py33, py34, py35
+envlist = py27, pypy, py34, py35
 
 [testenv]
+basepython =
+    py27: {env:TOXPYTHON:python2.7}
+    pypy: {env:TOXPYTHON:pypy}
+    py34: {env:TOXPYTHON:python3.4}
+    py35: {env:TOXPYTHON:python3.5}
 deps =
     pytest
     -rrequirements.txt
+install_command =
+    python -m pip install -v {opts} {packages}
 commands =
+    # check that we have the expected Python version and architecture
+    python -c "import sys; print(sys.version)"
+    python -c "import struct; print(struct.calcsize('P') * 8)"
+    # run the test suite
     py.test
 
 [pytest]


### PR DESCRIPTION
More info in the commit messages. In short, we were not actually testing the 64-bit Python 3.4, as tox was picking up the 32-bit interpreter... 😭 
