### PR TITLE
run coverage.py on Travis and upload report to coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,28 @@
+[run]
+# measure 'branch' coverage in addition to 'statement' coverage
+# See: http://coverage.readthedocs.org/en/coverage-4.0.3/branch.html#branch
+branch = True
+
+# list of directories to measure
+source =
+    Lib/fontTools
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # keywords to use in inline comments to skip coverage
+    pragma: no cover
+
+    # don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain if non-runnable code isn't run
+    if 0:
+    if __name__ == .__main__.:
+
+# ignore source code that can’t be found
+ignore_errors = True
+
+# when running a summary report, show missing lines
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
     - language: generic
       os: osx
       env: TOXENV=pypy
+    # coveralls is not listed in tox's envlist, but should run in travis
+    - python: 3.5
+      env: TOXENV=coveralls
 
 install:
   - ./.travis/install.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,16 +4,15 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    brew update || brew update
-    (brew list | grep -q 'pyenv') || brew install pyenv
-    brew outdated pyenv || brew upgrade pyenv
-
-    if which -s pyenv; then
-        eval "$(pyenv init -)"
-    fi
+    # install pyenv from the git repo (quicker than using brew)
+    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
 
     case "${TOXENV}" in
         py27)
+            # install pip on the system python
             curl -O https://bootstrap.pypa.io/get-pip.py
             python get-pip.py --user
             ;;
@@ -26,8 +25,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 3.4.3
             ;;
         py35)
-            pyenv install 3.5.0
-            pyenv global 3.5.0
+            pyenv install 3.5.1
+            pyenv global 3.5.1
             ;;
         pypy)
             pyenv install pypy-5.0.0
@@ -35,9 +34,9 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             ;;
     esac
     pyenv rehash
-    python -m pip install --user virtualenv
+    python -m pip install --user --upgrade pip virtualenv
 else
-    # install pyenv to get latest pypy
+    # on Linux, we only need pyenv to get the latest pypy
     if [[ "${TOXENV}" == "pypy" ]]; then
         git clone https://github.com/yyuu/pyenv.git ~/.pyenv
         PYENV_ROOT="$HOME/.pyenv"
@@ -45,10 +44,12 @@ else
         eval "$(pyenv init -)"
         pyenv install pypy-5.0.0
         pyenv global pypy-5.0.0
+        pyenv rehash
     fi
-    pip install virtualenv
+    pip install --upgrade pip virtualenv
 fi
 
+# activate virtualenv and install test requirements
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
 pip install -r dev-requirements.txt

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,14 +3,11 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
+if [[ "$(uname -s)" == "Darwin" || "${TOXENV}" == "pypy" ]]; then
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
-else
-    if [[ "${TOXENV}" == "pypy" ]]; then
-        PYENV_ROOT="$HOME/.pyenv"
-        PATH="$PYENV_ROOT/bin:$PATH"
-        eval "$(pyenv init -)"
-    fi
 fi
+
 source ~/.venv/bin/activate
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,20 @@ commands =
     # run the test suite
     py.test
 
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+basepython=python3.5
+deps =
+    {[testenv]deps}
+    pytest-cov
+    coveralls
+skip_install = true
+ignore_outcome = true
+commands=
+    # measure test coverage and upload report to coveralls
+    py.test --cov
+    coveralls
+
 [pytest]
 minversion = 2.8
 testpaths =

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ deps =
     pytest
     -rrequirements.txt
 install_command =
-    python -m pip install -v {opts} {packages}
+    {envpython} -m pip install -v {opts} {packages}
 commands =
     # check that we have the expected Python version and architecture
-    python -c "import sys; print(sys.version)"
-    python -c "import struct; print(struct.calcsize('P') * 8)"
+    {envpython} -c "import sys; print(sys.version)"
+    {envpython} -c "import struct; print(struct.calcsize('P') * 8)"
     # run the test suite
     py.test
 


### PR DESCRIPTION
I really recommend that we use [coverage.py](http://coverage.readthedocs.org/en/coverage-4.0.3) to measure our test suite coverage. It's really cool.
We even have a badge on the homepage, so we'd better use it! :)
However that link leads nowhere... https://coveralls.io/r/behdad/fonttools
Perhaps @behdad created it in the past but then decided to close it?
