### PR TITLE
[SVG] Better handling of empty <colorPalettes> element

### DIFF
--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -99,6 +99,9 @@ colorRecord_format_0 = """
 
 class table_S_V_G_(DefaultTable.DefaultTable):
 
+	def __init__(self, object):
+		self.colorPalettes = None
+
 	def decompile(self, data, ttFont):
 		self.docList = None
 		self.colorPalettes = None

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -302,10 +302,6 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 
 			writer.endtag("colorPalettes")
 			writer.newline()
-		else:
-			writer.begintag("colorPalettes")
-			writer.endtag("colorPalettes")
-			writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):
 		if name == "svgDoc":

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -343,7 +343,8 @@ class ColorPalettes(object):
 
 	def fromXML(self, name, attrs, content, ttFont):
 		for element in content:
-			if isinstance(element, type("")):
+			element = element.strip()
+			if not element:
 				continue
 			name, attrib, content = element
 			if name == "colorParamUINameID":


### PR DESCRIPTION
Before, when compiling from XML, only `<colorPalettes></colorPalettes>` would be accepted.
Now, all of these pass compilation as well,
```xml
<colorPalettes>    </colorPalettes>
```
```xml
<colorPalettes />
```
```xml
<colorPalettes>
</colorPalettes>
```