### PR TITLE
[SVG] correct __init__ method

### DIFF
--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -99,7 +99,8 @@ colorRecord_format_0 = """
 
 class table_S_V_G_(DefaultTable.DefaultTable):
 
-	def __init__(self, object):
+	def __init__(self, tag=None):
+		DefaultTable.DefaultTable.__init__(self, tag)
 		self.colorPalettes = None
 
 	def decompile(self, data, ttFont):


### PR DESCRIPTION
Something simple like this was failing:
```python
from fontTools import ttLib
fontFilePath = 'font-with-SVG-table.ttf'
font = ttLib.TTFont(fontFilePath)
print font['SVG ']
```

I took a clue from the [CFF table code](https://github.com/behdad/fonttools/blob/master/Lib/fontTools/ttLib/tables/C_F_F_.py#L10).