### PR TITLE
[sbix] correct __init__ method

### DIFF
--- a/Lib/fontTools/ttLib/tables/_s_b_i_x.py
+++ b/Lib/fontTools/ttLib/tables/_s_b_i_x.py
@@ -31,8 +31,9 @@ sbixStrikeOffsetFormatSize = sstruct.calcsize(sbixStrikeOffsetFormat)
 
 
 class table__s_b_i_x(DefaultTable.DefaultTable):
-	def __init__(self, tag):
-		self.tableTag = tag
+
+	def __init__(self, tag=None):
+		DefaultTable.DefaultTable.__init__(self, tag)
 		self.version = 1
 		self.flags = 1
 		self.numStrikes = 0


### PR DESCRIPTION
Similar to #584.
In this case, making an **sbix** table from scratch required this `_s_b_i_x.table__s_b_i_x('sbix')`, which is redundant. With this change it's only necessary to do this `_s_b_i_x.table__s_b_i_x()`.