### PR TITLE
varLib: use cElementTree if available to parse designspace

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -26,7 +26,10 @@ from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r, Axis, NamedInstance
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r, GlyphVariation
 import warnings
-import xml.etree.ElementTree as ET
+try:
+	import xml.etree.cElementTree as ET
+except ImportError:
+	import xml.etree.ElementTree as ET
 import os.path
 
 


### PR DESCRIPTION
The C implementation of ElementTree is included in CPython since 2.5.
It's got the same API and is up to 20 times faster than the Python implementation.
We'd better use it.