### PR TITLE
symfont: set dummify=False to fix "NameError: global name 'P' is not defined"

### DIFF
--- a/Snippets/symfont.py
+++ b/Snippets/symfont.py
@@ -49,7 +49,7 @@ def green(f, Bezier=BezierCurve[n]):
 	return sp.integrate(f2 * sp.diff(Bezier[0], t), (t, 0, 1))
 
 def lambdify(f):
-	return sp.lambdify(Psymbol, f)
+	return sp.lambdify(Psymbol, f, dummify=False)
 
 class BezierFuncs(object):
 


### PR DESCRIPTION
This should fix #595.

I'm not familiar with `sympy`. However, I noticed that if I call `lambdify` with argument `dummify=False`, then symfont works.

From http://docs.sympy.org/dev/modules/utilities/lambdify.html#sympy.utilities.lambdify.lambdify

> The default behavior is to substitute all arguments in the provided expression with dummy symbols... Call the function with dummify=False if dummy substitution is unwanted (and 'args' is not a string).

@behdad could you have a look?

Thanks @n8willis for trying out the symfont module and reporting the issue.