### PR TITLE
Rejct language statements when the script is DFLT or undefined

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -615,6 +615,12 @@ class Builder(object):
                 "within \"feature %s\"" % self.cur_feature_name_, location)
         self.cur_lookup_ = None
 
+        # OpenType Feature File Specification, section 4.b.ii
+        if (self.script_ in ("DFLT", None) and language != "dflt"):
+            raise FeatureLibError(
+                'The DFLT script cannot have any language systems '
+                'other then "dflt".' + repr(self.script_), location)
+
         key = (self.script_, language, self.cur_feature_name_)
         if not include_default:
             # don't include any lookups added by script DFLT in this feature

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -285,6 +285,13 @@ class BuilderTest(unittest.TestCase):
             "    substitute [a-z] by [A.sc-Z.sc];"
             "} test;")
 
+    def test_language_without_script(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            'The DFLT script cannot have any language systems '
+            'other then "dflt".',
+            self.build, "feature test { language RUS; } test;")
+
     def test_lookup_already_defined(self):
         self.assertRaisesRegex(
             FeatureLibError,


### PR DESCRIPTION
According to the OpenType Feature File Specification, section 4.b.ii,
the DFLT script cannot have any language systems other then "dflt".
Adobe's makeotf rejects such input as well.