### PR TITLE
Snippets: add 'merge_woff_metadata.py' and 'dump_woff_metatada.py' scripts

### DIFF
--- a/Snippets/dump_woff_metadata.py
+++ b/Snippets/dump_woff_metadata.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+from fontTools.ttx import makeOutputFileName
+from fontTools.ttLib import TTFont
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    if len(args) < 1:
+        print("usage: dump_woff_metadata.py "
+              "INPUT.woff [OUTPUT.xml]", file=sys.stderr)
+        return 1
+
+    infile = args[0]
+    if len(args) > 1:
+        outfile = args[1]
+    else:
+        outfile = makeOutputFileName(infile, None, ".xml")
+
+    font = TTFont(infile)
+
+    if not font.flavorData or not font.flavorData.metaData:
+        print("No WOFF metadata")
+        return 1
+
+    with open(outfile, "wb") as f:
+        f.write(font.flavorData.metaData)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Snippets/merge_woff_metadata.py
+++ b/Snippets/merge_woff_metadata.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+import sys
+import os
+from fontTools.ttx import makeOutputFileName
+from fontTools.ttLib import TTFont
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    if len(args) < 2:
+        print("usage: merge_woff_metadata.py METADATA.xml "
+              "INPUT.woff [OUTPUT.woff]", file=sys.stderr)
+        return 1
+
+    metadata_file = args[0]
+    with open(metadata_file, 'rb') as f:
+        metadata = f.read()
+
+    infile = args[1]
+    if len(args) > 2:
+        outfile = args[2]
+    else:
+        filename, ext = os.path.splitext(infile)
+        outfile = makeOutputFileName(filename, None, ext)
+
+    font = TTFont(infile)
+
+    if font.flavorData is None:
+        font.flavorData = WOFFFlavorData()
+
+    data = font.flavorData
+
+    # this sets the new WOFF metadata
+    data.metaData = metadata
+
+    font.save(outfile)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Snippets/merge_woff_metadata.py
+++ b/Snippets/merge_woff_metadata.py
@@ -27,8 +27,9 @@ def main(args=None):
 
     font = TTFont(infile)
 
-    if font.flavorData is None:
-        font.flavorData = WOFFFlavorData()
+    if font.flavor not in ("woff", "woff2"):
+        print("Input file is not a WOFF or WOFF2 font", file=sys.stderr)
+        return 1
 
     data = font.flavorData
 


### PR DESCRIPTION
This is just to exemplify how one could use the `TTFont.flavorData` attribute to get/set the WOFF metadata, as @antonxheight asked in https://github.com/behdad/fonttools/issues/630

I'm not sure if something like this should/could be integrated in the main ttx script. 