### PR TITLE
Fix xml-roundtripping of CFF fonts (name-keyed & cid-keyed)

### DIFF
--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -547,7 +547,7 @@ class CharStrings(object):
 		else:
 			if hasattr(self, 'fdArray'):
 				if hasattr(self, 'fdSelect'):
-					sel = self.fdSelect[index]  # index is not defined at this point. Read R. ?
+					sel = self.charStrings[name].fdSelectIndex
 				else:
 					raise KeyError("fdSelect array not yet defined.")
 			else:

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -545,10 +545,13 @@ class CharStrings(object):
 			index = self.charStrings[name]
 			return self.charStringsIndex.getItemAndSelector(index)
 		else:
-			if hasattr(self, 'fdSelect'):
-				sel = self.fdSelect[index]  # index is not defined at this point. Read R. ?
+			if hasattr(self, 'fdArray'):
+				if hasattr(self, 'fdSelect'):
+					sel = self.fdSelect[index]  # index is not defined at this point. Read R. ?
+				else:
+					raise KeyError("fdSelect array not yet defined.")
 			else:
-				raise KeyError("fdSelect array not yet defined.")
+				sel = None
 			return self.charStrings[name], sel
 
 	def toXML(self, xmlWriter, progress):


### PR DESCRIPTION
Something like this was failing,
```python
from fontTools.ttLib import TTFont

font = TTFont()
font.importXML('myFont.ttx')
font.saveXML('myNewFont.ttx')
```