### PR TITLE
[feaLib] ignore stray semicolons

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -49,6 +49,8 @@ class Parser(object):
             elif self.is_cur_keyword_("valueRecordDef"):
                 statements.append(
                     self.parse_valuerecord_definition_(vertical=False))
+            elif self.cur_token_type_ is Lexer.SYMBOL and self.cur_token_ == ";":
+                continue
             else:
                 raise FeatureLibError(
                     "Expected feature, languagesystem, lookup, markClass, "

--- a/Lib/fontTools/feaLib/parser_test.py
+++ b/Lib/fontTools/feaLib/parser_test.py
@@ -1242,6 +1242,8 @@ class ParserTest(unittest.TestCase):
     def test_empty_statement_ignored(self):
         doc = self.parse("feature test {;} test;")
         self.assertFalse(doc.statements[0].statements)
+        doc = self.parse(";;;")
+        self.assertFalse(doc.statements)
 
     def setUp(self):
         self.tempdir = None


### PR DESCRIPTION
This addresses issue #641.

in https://github.com/behdad/fonttools/commit/7eed24725f33c76d033e40888d865e13d47622c2, Sascha allowed the `include` statement to not be followed by a semicolon.
However, the symbol is not eaten up by the Lexer, but is passed on to the Parser, which barks at it because it does not expect a stray SYMBOL ";" at the top level of a feature file.

I tested with makeotf, and confirmed that it ignores any extra semicolons which appear in a feature file. I guess we can do the same.
