### PR TITLE
requirements.txt: download Brotli 0.4.0 pre-compiled wheel from Github Releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-git+https://github.com/google/brotli@v0.3.0#egg=Brotli
+--find-links https://github.com/google/brotli/releases
+brotli==0.4.0


### PR DESCRIPTION
This should speed up the Travis and Appveyor builds, as we don't need to compile Brotli from source, at least on OSX and Windows.
Linux will still use the .tag.gz source distribution.