### PR TITLE
feaLib: limit language statements to 1 feature block 

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -94,7 +94,14 @@ class FeatureBlock(Block):
     def build(self, builder):
         # TODO(sascha): Handle use_extension.
         builder.start_feature(self.location, self.name)
+        # language exclude_dflt statements modify builder.features_
+        # limit them to this block with temporary builder.features_
+        features = builder.features_
+        builder.features_ = {}
         Block.build(self, builder)
+        for key, value in builder.features_.items():
+            features.setdefault(key, []).extend(value)
+        builder.features_ = features
         builder.end_feature()
 
 

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -59,7 +59,7 @@ class BuilderTest(unittest.TestCase):
         spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
         spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f
         bug453 bug463 bug501 bug502 bug504 bug505 bug506 bug509 bug512 bug568
-        name size size2
+        name size size2 multiple_feature_blocks
     """.split()
 
     def __init__(self, methodName):

--- a/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.fea
+++ b/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.fea
@@ -1,0 +1,18 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+languagesystem latn TRK;
+
+feature liga {
+    lookup liga_fl {
+        sub f l by f_l;
+    } liga_fl;
+} liga;
+
+feature liga {
+    lookup liga_fi {
+        sub f i by f_i;
+    } liga_fi;
+
+    script latn;
+    language TRK exclude_dflt;
+} liga;

--- a/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.ttx
+++ b/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.ttx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.0">
+
+  <GSUB>
+    <Version value="1.0"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=1 -->
+              <FeatureIndex index="0" value="0"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="f">
+            <Ligature components="l" glyph="f_l"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="1">
+        <!-- LookupType=4 -->
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="f">
+            <Ligature components="i" glyph="f_i"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
When a feature is defined in more than one block, the language statement exclude_dflt should not apply to all the dflt lookups but only those defined in the block of the language statement.

For example, feaLib doesn’t compile to following correctly. The latn TRK language system is completely dropped.

```
languagesystem DFLT dflt;
languagesystem latn dflt;
languagesystem latn TRK;

feature liga {
    lookup liga_fl {
        sub f l by f_l;
    } liga_fl;
} liga;

feature liga {
    lookup liga_fi {
        sub f i by f_i;
    } liga_fi;

    script latn;
    language TRK exclude_dflt;
} liga;
```

For AFDKO, this is equivalent to the following.
```
languagesystem DFLT dflt;
languagesystem latn dflt;
languagesystem latn TRK;

feature liga {
    lookup liga_fl {
        sub f l by f_l;
    } liga_fl;

    lookup liga_fi {
        sub f i by f_i;
    } liga_fi;

    script latn;
    language TRK exclude_dflt;
    lookup liga_fl;
} liga;
```