### PR TITLE
varlib/builder.py:

### DIFF
--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -5,6 +5,8 @@ from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
 from fontTools.misc import psCharStrings
 from fontTools.misc.textTools import safeEval
+from fontTools.ttLib.tables.otBase  import BaseTTXConverter
+from fontTools.ttLib.tables.otBase  import BaseTable
 import struct
 import logging
 
@@ -28,19 +30,28 @@ class CFFFontSet(object):
 
 	def decompile(self, file, otFont):
 		sstruct.unpack(cffHeaderFormat, file.read(4), self)
-		assert self.major == 1 and self.minor == 0, \
+		assert ((self.major == 1 and self.minor == 0) or (self.major == 2 and self.minor == 0)), \
 				"unknown CFF format: %d.%d" % (self.major, self.minor)
 
 		file.seek(self.hdrSize)
-		self.fontNames = list(Index(file))
-		self.topDictIndex = TopDictIndex(file)
-		self.strings = IndexedStrings(file)
-		self.GlobalSubrs = GlobalSubrsIndex(file)
-		self.topDictIndex.strings = self.strings
-		self.topDictIndex.GlobalSubrs = self.GlobalSubrs
+		if self.major == 1:
+			self.fontNames = list(Index(file))
+			self.topDictIndex = TopDictIndex(file)
+			self.strings = IndexedStrings(file)
+			self.GlobalSubrs = GlobalSubrsIndex(file)
+			self.topDictIndex.strings = self.strings
+			self.topDictIndex.GlobalSubrs = self.GlobalSubrs
+		else: # major is 2.
+			self.fontNames = ["CFF2Font"]
+			self.topDictIndex = TopDictIndex(file)
+			self.strings = IndexedStrings(file)
+			self.GlobalSubrs = GlobalSubrsIndex(file)
+			self.topDictIndex.strings = self.strings
+			self.topDictIndex.GlobalSubrs = self.GlobalSubrs
 
 	def __len__(self):
 		return len(self.fontNames)
+		
 
 	def keys(self):
 		return list(self.fontNames)
@@ -59,19 +70,26 @@ class CFFFontSet(object):
 		strings = IndexedStrings()
 		writer = CFFWriter()
 		writer.add(sstruct.pack(cffHeaderFormat, self))
-		fontNames = Index()
-		for name in self.fontNames:
-			fontNames.append(name)
-		writer.add(fontNames.getCompiler(strings, None))
-		topCompiler = self.topDictIndex.getCompiler(strings, None)
+		if self.major == 1:
+			fontNames = Index()
+			for name in self.fontNames:
+				fontNames.append(name)
+			writer.add(fontNames.getCompiler(strings, None))
+		topCompiler = self.topDictIndex.getCompiler(strings, self)
 		writer.add(topCompiler)
 		writer.add(strings.getCompiler())
 		writer.add(self.GlobalSubrs.getCompiler(strings, None))
 
 		for topDict in self.topDictIndex:
 			if not hasattr(topDict, "charset") or topDict.charset is None:
-				charset = otFont.getGlyphOrder()
-				topDict.charset = charset
+				if self.major == 1:
+					topDict.charset = 0
+				else:
+					charset = otFont.getGlyphOrder()
+					topDict.charset = charset
+			if self.major > 1:
+				if hasattr(topDict, "Encoding"):
+					del topDict.Encoding
 
 		for child in topCompiler.getChildren(strings):
 			writer.add(child)
@@ -101,13 +119,15 @@ class CFFFontSet(object):
 			self.hdrSize = 4
 			self.offSize = 4  # XXX ??
 		if name == "CFFFont":
-			if not hasattr(self, "fontNames"):
-				self.fontNames = []
-				self.topDictIndex = TopDictIndex()
-			fontName = attrs["name"]
+			self.topDictIndex = TopDictIndex()
+			if self.major == 1:
+				if not hasattr(self, "fontNames"):
+					self.fontNames = []
+				fontName = attrs["name"]
+				self.fontNames.append(fontName)
 			topDict = TopDict(GlobalSubrs=self.GlobalSubrs)
-			topDict.charset = None  # gets filled in later
-			self.fontNames.append(fontName)
+			if self.major == 1:
+				topDict.charset = None  # gets filled in later
 			self.topDictIndex.append(topDict)
 			for element in content:
 				if isinstance(element, basestring):
@@ -444,12 +464,24 @@ class FDArrayIndex(TopDictIndex):
 			fontDict.fromXML(name, attrs, content)
 		self.append(fontDict)
 
+class	VarStore:
+	def __init__(self, file=None, data = None):
+		if file:
+			# read data in from file
+			length = readCard16(file)
+			self.data = file.read(length)
+		else:
+			self.data = data
+			
+	def __len__(self):
+		return len(self.data)
+
 
 class	FDSelect:
 	def __init__(self, file=None, numGlyphs=None, format=None):
 		if file:
 			# read data in from file
-			self.format = readCard8(file)
+			length = readCard16(file)
 			if self.format == 0:
 				from array import array
 				self.gidArray = array("B", file.read(numGlyphs)).tolist()
@@ -545,13 +577,10 @@ class CharStrings(object):
 			index = self.charStrings[name]
 			return self.charStringsIndex.getItemAndSelector(index)
 		else:
-			if hasattr(self, 'fdArray'):
-				if hasattr(self, 'fdSelect'):
-					sel = self.charStrings[name].fdSelectIndex
-				else:
-					raise KeyError("fdSelect array not yet defined.")
+			if hasattr(self, 'fdSelect'):
+				sel = self.fdSelect[index]  # index is not defined at this point. Read R. ?
 			else:
-				sel = None
+				raise KeyError("fdSelect array not yet defined.")
 			return self.charStrings[name], sel
 
 	def toXML(self, xmlWriter, progress):
@@ -699,18 +728,70 @@ def parseNum(s):
 		value = float(s)
 	return value
 
+def parseBlendList(s):
+	valueList = []
+	for element in s:
+		if isinstance(element, basestring):
+			continue
+		name, attrs, content = element
+		blendList = attrs["value"].split()
+		blendList = map(eval, blendList)
+		valueList.append(blendList)
+	return valueList
+	
 class NumberConverter(SimpleConverter):
+	def xmlWrite(self, xmlWriter, name, value, progress):
+		if isinstance(value, list):
+			xmlWriter.begintag(name)
+			xmlWriter.newline()
+			xmlWriter.indent()
+			valueList = value[-2]
+			blendValue = " ".join(map(str, valueList))
+			xmlWriter.simpletag(kBlendDictOpName, value=blendValue)
+			xmlWriter.newline()
+			xmlWriter.dedent()
+			xmlWriter.endtag(name)
+			xmlWriter.newline()
+		else:
+			xmlWriter.simpletag(name, value=value)
+			xmlWriter.newline()
+		
 	def xmlRead(self, name, attrs, content, parent):
-		return parseNum(attrs["value"])
+		valueString = attrs.get("value", None)
+		if valueString == None:
+			value = parseBlendList(content)
+		else:
+			value = parseNum(attrs["value"])
+		return value
 
 class ArrayConverter(SimpleConverter):
 	def xmlWrite(self, xmlWriter, name, value, progress):
-		value = " ".join(map(str, value))
-		xmlWriter.simpletag(name, value=value)
-		xmlWriter.newline()
+		if isinstance(value[0], list):
+			xmlWriter.begintag(name)
+			xmlWriter.newline()
+			xmlWriter.indent()
+			for valueList in value:
+				blendValue = " ".join(map(str, valueList))
+				xmlWriter.simpletag(kBlendDictOpName, value=blendValue)
+				xmlWriter.newline()
+			xmlWriter.dedent()
+			xmlWriter.endtag(name)
+			xmlWriter.newline()
+		else:
+			value = " ".join(map(str, value))
+			xmlWriter.simpletag(name, value=value)
+			xmlWriter.newline()
 	def xmlRead(self, name, attrs, content, parent):
-		values = attrs["value"].split()
-		return [parseNum(value) for value in values]
+		valueString = attrs.get("value", None)
+		if valueString == None:
+			valueList = parseBlendList(content)
+		else:
+			values = valueString.split()
+			valueList = [parseNum(value) for value in values]
+		return valueList
+
+class BlendConverter(SimpleConverter):
+	pass
 
 class TableConverter(SimpleConverter):
 	def xmlWrite(self, xmlWriter, name, value, progress):
@@ -1139,6 +1220,28 @@ class FDSelectConverter(object):
 		fdSelect = FDSelect(file, numGlyphs, fmt)
 		return fdSelect
 
+class VarStoreConverter(BaseTable):
+
+	def read(self, parent, value):
+		file = parent.file
+		file.seek(value)
+		varStore = VarStore(file)
+		return 	varStore
+
+	def write(self, parent, value):
+		return 0  # dummy value
+
+	def xmlWrite(self, xmlWriter, name, value, progress):
+		xmlWriter.simpletag(name, [('data', repr(value.data))])
+		xmlWriter.newline()
+
+	def xmlRead(self, name, attrs, content, parent):
+		file = None
+		data = attrs['data']
+		data = eval(data)
+		varStore = VarStore(None, data)
+		return varStore
+
 
 def packFDSelect0(fdSelectArray):
 	fmt = 0
@@ -1202,6 +1305,22 @@ class FDSelectCompiler(object):
 	def toFile(self, file):
 		file.write(self.data)
 
+class VarStoreCompiler(object):
+
+	def __init__(self, varStore, parent):
+		data = [packCard16(len(varStore.data))]
+		data.append(varStore.data)
+		self.parent = parent
+		self.data = bytesjoin(data)
+
+	def setPos(self, pos, endPos):
+		self.parent.rawDict["VarStore"] = pos
+
+	def getDataLength(self):
+		return len(self.data)
+
+	def toFile(self, file):
+		file.write(self.data)
 
 class ROSConverter(SimpleConverter):
 
@@ -1214,6 +1333,11 @@ class ROSConverter(SimpleConverter):
 	def xmlRead(self, name, attrs, content, parent):
 		return (attrs['Registry'], attrs['Order'], safeEval(attrs['Supplement']))
 
+kBlendDictOpName = "blend"
+blendOp = 31
+
+kVSIndexOpName = "vsindex"
+vsIndexOp = 22
 
 topDictOperators = [
 #	opcode		name			argument type	default	converter
@@ -1244,18 +1368,22 @@ topDictOperators = [
 	((12, 32),	'CIDFontRevision',	'number',	0,	None),
 	((12, 33),	'CIDFontType',		'number',	0,	None),
 	((12, 34),	'CIDCount',		'number',	8720,	None),
-	(15,		'charset',		'number',	0,	CharsetConverter()),
+	(15,		'charset',		'number',	None,	CharsetConverter()),
 	((12, 35),	'UIDBase',		'number',	None,	None),
 	(16,		'Encoding',		'number',	0,	EncodingConverter()),
 	(18,		'Private',	('number', 'number'),	None,	PrivateDictConverter()),
 	((12, 37),	'FDSelect',		'number',	None,	FDSelectConverter()),
 	((12, 36),	'FDArray',		'number',	None,	FDArrayConverter()),
 	(17,		'CharStrings',		'number',	None,	CharStringsConverter()),
+	(blendOp,	kBlendDictOpName,		'blendList',	None,	None), # This is for reading to/from XML: it not written to CFF.
+	(vsIndexOp,	kVSIndexOpName,		'number',	None,	None), # This is for reading to/from XML: it not written to CFF.
+	(24,		'VarStore',		'number',	None,	VarStoreConverter()),
+	(25,		'maxstack',		'number',	None,	None),
 ]
+
 
 # Note! FDSelect and FDArray must both preceed CharStrings in the output XML build order,
 # in order for the font to compile back from xml.
-
 
 privateDictOperators = [
 #	opcode		name			argument type	default	converter
@@ -1279,6 +1407,8 @@ privateDictOperators = [
 	(20,		'defaultWidthX',	'number',	0,	None),
 	(21,		'nominalWidthX',	'number',	0,	None),
 	(19,		'Subrs',		'number',	None,	SubrsConverter()),
+	(blendOp,	kBlendDictOpName,		'blendList',	None,	None), # This is for reading to/from XML: it not written to CFF.
+	(vsIndexOp,	kVSIndexOpName,		'number',	None,	None), # This is for reading to/from XML: it not written to CFF.
 ]
 
 def addConverters(table):
@@ -1292,6 +1422,8 @@ def addConverters(table):
 			conv = NumberConverter()
 		elif arg == "SID":
 			conv = ASCIIConverter()
+		elif arg == 'blendList':
+			conv = None
 		else:
 			assert False
 		table[i] = op, name, arg, default, conv
@@ -1360,24 +1492,71 @@ class DictCompiler(object):
 		file.write(self.compile("toFile"))
 
 	def arg_number(self, num):
-		return encodeNumber(num)
+		if isinstance(num, list):
+			blendList = num
+			firstNum = blendList[0]
+			data = [firstNum]
+			for blendNum in blendList[1:]:
+				data.append(blendNum - firstNum)
+			data = map(encodeNumber, data)
+			data.append(encodeNumber(1))
+			data.append(bytechr(blendOp))
+			datum = bytesjoin(data)
+		else:
+			datum = encodeNumber(num)
+		return datum
 	def arg_SID(self, s):
 		return psCharStrings.encodeIntCFF(self.strings.getSID(s))
 	def arg_array(self, value):
 		data = []
 		for num in value:
-			data.append(encodeNumber(num))
+			data.append(self.arg_number(num))
 		return bytesjoin(data)
 	def arg_delta(self, value):
-		out = []
-		last = 0
-		for v in value:
-			out.append(v - last)
-			last = v
-		data = []
-		for num in out:
-			data.append(encodeNumber(num))
+		val0 = value[0]
+		if isinstance(val0, list):
+			data = self.arg_delta_blend(value)
+		else:
+			out = []
+			last = 0
+			for v in value:
+				out.append(v - last)
+				last = v
+			data = []
+			for num in out:
+				data.append(encodeNumber(num))
 		return bytesjoin(data)
+
+	def arg_delta_blend(self, value):
+		#  A delta list with blend lists has to be *all" blend lists.
+		# We have a list of master value lists, where the nth 
+		# master value list contains the absolute values from each master for the nth entry in the current array.
+		# We first convert these to relative values from the previous entry.
+		numMasters = len(value[0])
+		numValues = len(value)
+		currentList = numMasters*[0]
+		firstList = [0]*numValues
+		deltaList = [None]*(numValues)
+		i = 0
+		while i < numValues:
+			masterValList =  value[i]
+			firstVal = firstList[i] = masterValList[0]
+			j = 1
+			deltaEntry = (numMasters-1)*[0]
+			while j < numMasters:
+				deltaEntry[j-1] = masterValList[j] -firstVal 
+				j += 1
+			deltaList[i] = deltaEntry
+			i +=1
+				
+		relValueList = firstList
+		for blendList in deltaList:
+			relValueList.extend(blendList)
+		
+		out = map(encodeNumber, relValueList)
+		out.append(encodeNumber(numValues))
+		out.append(bytechr(blendOp))
+		return out
 
 
 def encodeNumber(num):
@@ -1399,6 +1578,10 @@ class TopDictCompiler(DictCompiler):
 			encoding = self.dictObj.Encoding
 			if not isinstance(encoding, basestring):
 				children.append(EncodingCompiler(strings, encoding, self))
+		if hasattr(self.dictObj, "VarStore"):
+			varStore = self.dictObj.VarStore
+			varStoreComp = VarStoreCompiler(varStore, self)
+			children.append(varStoreComp)
 		if hasattr(self.dictObj, "FDSelect"):
 			# I have not yet supported merging a ttx CFF-CID font, as there are interesting
 			# issues about merging the FDArrays. Here I assume that
@@ -1429,6 +1612,7 @@ class TopDictCompiler(DictCompiler):
 			privComp = self.dictObj.Private.getCompiler(strings, self)
 			children.append(privComp)
 			children.extend(privComp.getChildren(strings))
+			
 		return children
 
 
@@ -1471,6 +1655,7 @@ class BaseDict(object):
 		self.offset = offset
 		self.strings = strings
 		self.skipNames = []
+		self.numMasters = 0
 
 	def decompile(self, data):
 		log.log(DEBUG, "    length %s is %d", self.__class__.__name__, len(data))

--- a/Lib/fontTools/ttLib/tables/C_F_F_V_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_V_.py
@@ -1,0 +1,7 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from .otBase import BaseTTXConverter
+
+
+class table_C_F_F_V_(BaseTTXConverter):
+	pass

--- a/Lib/fontTools/ttLib/tables/C_F_F__2.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F__2.py
@@ -1,0 +1,47 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools import cffLib
+from . import DefaultTable
+
+
+class table_C_F_F__2(DefaultTable.DefaultTable):
+
+	def __init__(self, tag=None):
+		DefaultTable.DefaultTable.__init__(self, tag)
+		self.cff = cffLib.CFFFontSet()
+		self._gaveGlyphOrder = False
+
+	def decompile(self, data, otFont):
+		self.cff.decompile(BytesIO(data), otFont)
+		assert len(self.cff) < 2, "can't deal with multi-font CFF tables."
+
+	def compile(self, otFont):
+		f = BytesIO()
+		self.cff.compile(f, otFont)
+		return f.getvalue()
+
+	def haveGlyphNames(self):
+		if hasattr(self.cff[self.cff.fontNames[0]], "ROS"):
+			return False  # CID-keyed font
+		else:
+			return True
+
+	def getGlyphOrder(self):
+		if self._gaveGlyphOrder:
+			from fontTools import ttLib
+			raise ttLib.TTLibError("illegal use of getGlyphOrder()")
+		self._gaveGlyphOrder = True
+		return self.cff[self.cff.fontNames[0]].getGlyphOrder()
+
+	def setGlyphOrder(self, glyphOrder):
+		pass
+		# XXX
+		#self.cff[self.cff.fontNames[0]].setGlyphOrder(glyphOrder)
+
+	def toXML(self, writer, otFont, progress=None):
+		self.cff.toXML(writer, progress)
+
+	def fromXML(self, name, attrs, content, otFont):
+		if not hasattr(self, "cff"):
+			self.cff = cffLib.CFFFontSet()
+		self.cff.fromXML(name, attrs, content)

--- a/Lib/fontTools/ttLib/tables/H_V_A_R_.py
+++ b/Lib/fontTools/ttLib/tables/H_V_A_R_.py
@@ -1,0 +1,7 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from .otBase import BaseTTXConverter
+
+
+class table_H_V_A_R_(BaseTTXConverter):
+	pass

--- a/Lib/fontTools/ttLib/tables/V_V_A_R_.py
+++ b/Lib/fontTools/ttLib/tables/V_V_A_R_.py
@@ -1,0 +1,7 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from .otBase import BaseTTXConverter
+
+
+class table_V_V_A_R_(BaseTTXConverter):
+	pass

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -24,6 +24,7 @@ def _moduleFinderHint():
 	from . import G_P_K_G_
 	from . import G_P_O_S_
 	from . import G_S_U_B_
+	from . import H_V_A_R_
 	from . import J_S_T_F_
 	from . import L_T_S_H_
 	from . import M_A_T_H_
@@ -44,6 +45,7 @@ def _moduleFinderHint():
 	from . import T_S_I__5
 	from . import V_D_M_X_
 	from . import V_O_R_G_
+	from . import V_V_A_R_
 	from . import _a_v_a_r
 	from . import _c_m_a_p
 	from . import _c_v_t

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -13,6 +13,8 @@ def _moduleFinderHint():
 	from . import C_B_D_T_
 	from . import C_B_L_C_
 	from . import C_F_F_
+	from . import C_F_F__2
+	from . import C_F_F_V_
 	from . import C_O_L_R_
 	from . import C_P_A_L_
 	from . import D_S_I_G_

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -164,6 +164,13 @@ class OTTableReader(object):
 		self.pos = newpos
 		return value
 
+	def readInt8(self):
+		pos = self.pos
+		newpos = pos + 1
+		value, = struct.unpack(">b", self.data[pos:newpos])
+		self.pos = newpos
+		return value
+
 	def readShort(self):
 		pos = self.pos
 		newpos = pos + 2
@@ -434,6 +441,10 @@ class OTTableWriter(object):
 	def writeUInt8(self, value):
 		assert 0 <= value < 256
 		self.items.append(struct.pack(">B", value))
+
+	def writeInt8(self, value):
+		assert -128 <= value < 127
+		self.items.append(struct.pack(">b", value))
 
 	def writeUInt24(self, value):
 		assert 0 <= value < 0x1000000, value

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -436,14 +436,15 @@ class OTTableWriter(object):
 		self.items.append(struct.pack(">H", value))
 
 	def writeShort(self, value):
+		assert -32768 <= value < 32768, value
 		self.items.append(struct.pack(">h", value))
 
 	def writeUInt8(self, value):
-		assert 0 <= value < 256
+		assert 0 <= value < 256, value
 		self.items.append(struct.pack(">B", value))
 
 	def writeInt8(self, value):
-		assert -128 <= value < 127
+		assert -128 <= value < 128, value
 		self.items.append(struct.pack(">b", value))
 
 	def writeUInt24(self, value):

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -227,6 +227,13 @@ class GlyphID(SimpleValue):
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeUShort(font.getGlyphID(value))
 
+class VarAxisID(SimpleValue):
+	staticSize = 2
+	def read(self, reader, font, tableDict):
+		return font['fvar'].axes[reader.readUShort()]
+	def write(self, writer, font, tableDict, value, repeatIndex=None):
+		writer.writeUShort(font['fvar'].axes.index(value))
+
 class FloatValue(SimpleValue):
 	def xmlRead(self, attrs, content, font):
 		return float(attrs["value"])

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -178,6 +178,13 @@ class UShort(IntValue):
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeUShort(value)
 
+class Int8(IntValue):
+	staticSize = 1
+	def read(self, reader, font, tableDict):
+		return reader.readInt8()
+	def write(self, writer, font, tableDict, value, repeatIndex=None):
+		writer.writeInt8(value)
+
 class UInt8(IntValue):
 	staticSize = 1
 	def read(self, reader, font, tableDict):
@@ -238,6 +245,13 @@ class Fixed(FloatValue):
 		return  fi2fl(reader.readLong(), 16)
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeLong(fl2fi(value, 16))
+
+class F2Dot14(FloatValue):
+	staticSize = 2
+	def read(self, reader, font, tableDict):
+		return  fi2fl(reader.readShort(), 14)
+	def write(self, writer, font, tableDict, value, repeatIndex=None):
+		writer.writeShort(fl2fi(value, 14))
 
 class Version(BaseConverter):
 	staticSize = 4
@@ -476,7 +490,9 @@ class DeltaValue(BaseConverter):
 
 converterMapping = {
 	# type		class
+	"int8":		Int8,
 	"int16":	Short,
+	"uint8":	UInt8,
 	"uint8":	UInt8,
 	"uint16":	UShort,
 	"uint24":	UInt24,

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -558,6 +558,44 @@ class VarIdxMapValue(BaseConverter):
 			write(raw)
 
 
+class VarDataValue(BaseConverter):
+
+	def read(self, reader, font, tableDict):
+		values = []
+
+		regionCount = tableDict["VarRegionCount"]
+		shortCount = tableDict["NumShorts"]
+
+		for i in range(min(regionCount, shortCount)):
+			values.append(reader.readShort())
+		for i in range(min(regionCount, shortCount), regionCount):
+			values.append(reader.readInt8())
+		for i in range(regionCount, shortCount):
+			reader.readInt8()
+
+		return values
+
+
+
+	def write(self, writer, font, tableDict, value, repeatIndex=None):
+		regionCount = tableDict["VarRegionCount"]
+		shortCount = tableDict["NumShorts"]
+
+		for i in range(min(regionCount, shortCount)):
+			writer.writeShort(value[i])
+		for i in range(min(regionCount, shortCount), regionCount):
+			writer.writeInt8(value[i])
+		for i in range(regionCount, shortCount):
+			writer.writeInt8(0)
+
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.simpletag(name, attrs + [("value", value)])
+		xmlWriter.newline()
+
+	def xmlRead(self, attrs, content, font):
+		return safeEval(attrs["value"])
+
+
 converterMapping = {
 	# type		class
 	"int8":		Int8,
@@ -580,6 +618,7 @@ converterMapping = {
 	"VarAxisID":	VarAxisID,
 	"DeltaValue":	DeltaValue,
 	"VarIdxMapValue":	VarIdxMapValue,
+	"VarDataValue":	VarDataValue,
 	# "Template" types
 	"OffsetTo":	lambda C: partial(Table, tableClass=C),
 	"LOffsetTo":	lambda C: partial(LTable, tableClass=C),

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -575,8 +575,6 @@ class VarDataValue(BaseConverter):
 
 		return values
 
-
-
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		regionCount = tableDict["VarRegionCount"]
 		shortCount = tableDict["NumShorts"]

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -22,8 +22,11 @@ def buildConverters(tableSpec, tableNamespace):
 			assert tp == "uint16"
 			converterClass = ValueFormat
 		elif name.endswith("Count") or name.endswith("LookupType"):
-			assert tp == "uint16"
-			converterClass = ComputedUShort
+			assert tp in [ "uint16", "uint32"]
+			if tp == "uint16":
+				converterClass = ComputedUShort
+			else:
+				converterClass = ComputedULong
 		elif name == "SubTable":
 			converterClass = SubTable
 		elif name == "ExtSubTable":
@@ -92,6 +95,7 @@ class BaseConverter(object):
 		self.aux = aux
 		self.tableClass = tableClass
 		self.isCount = name.endswith("Count")
+		self.isLongCount = name in ['FeatureVariationRecordsCount']
 		self.isLookupType = name.endswith("LookupType")
 		self.isPropagated = name in ["ClassCount", "Class2Count", "FeatureTag", "SettingsCount", "VarRegionCount", "MappingCount", "RegionAxisCount"]
 
@@ -204,6 +208,11 @@ class UInt24(IntValue):
 		writer.writeUInt24(value)
 
 class ComputedUShort(UShort):
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.comment("%s=%s" % (name, value))
+		xmlWriter.newline()
+
+class ComputedULong(ULong):
 	def xmlWrite(self, xmlWriter, font, value, name, attrs):
 		xmlWriter.comment("%s=%s" % (name, value))
 		xmlWriter.newline()

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -93,7 +93,7 @@ class BaseConverter(object):
 		self.tableClass = tableClass
 		self.isCount = name.endswith("Count")
 		self.isLookupType = name.endswith("LookupType")
-		self.isPropagated = name in ["ClassCount", "Class2Count", "FeatureTag", "SettingsCount", "VarTupleCount", "MappingCount"]
+		self.isPropagated = name in ["ClassCount", "Class2Count", "FeatureTag", "SettingsCount", "VarRegionCount", "MappingCount", "RegionAxisCount"]
 
 	def readArray(self, reader, font, tableDict, count):
 		"""Read an array of values from the reader."""

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -837,6 +837,56 @@ otData = [
 	]),
 
 	#
+	# variations
+	#
+	('VarAxis', [
+		('uint16', 'AxisIndex', None, None, ''),
+		('F2Dot14', 'StartCoord', None, None, ''),
+		('F2Dot14', 'PeakCoord', None, None, ''),
+		('F2Dot14', 'EndCoord', None, None, ''),
+	]),
+
+	('VarTuple', [
+		('uint16', 'VarAxisCount', None, None, ''),
+		('struct', 'VarAxis', 'VarAxisCount', 0, ''),
+	]),
+
+	('VarTupleList', [
+		('uint16', 'VarTupleCount', None, None, ''),
+		('LOffset', 'VarTuple', 'VarTupleCount', 0, ''),
+	]),
+
+	('VarItemByteRecord', [
+		('int8', 'deltas', 'VarTupleCount', 0, ''),
+	]),
+	('VarItemShortRecord', [
+		('int16', 'deltas', 'VarTupleCount', 0, ''),
+	]),
+
+	('VarDeltasFormat1', [
+		('uint16', 'Format', None, None, 'Set to 1.'),
+		('uint16', 'ItemCount', None, None, ''),
+		('uint16', 'VarTupleCount', None, None, ''),
+		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
+		('struct', 'VarItemByteRecord', 'ItemCount', 0, ''),
+	]),
+
+	('VarDeltasFormat2', [
+		('uint16', 'Format', None, None, 'Set to 2.'),
+		('uint16', 'ItemCount', None, None, ''),
+		('uint16', 'VarTupleCount', None, None, ''),
+		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
+		('struct', 'VarItemShortRecord', 'ItemCount', 0, ''),
+	]),
+
+	('VarStore', [
+		('LOffset', 'VarTupleList', None, None, ''),
+		('uint16', 'Format', None, None, 'Set to 1.'),
+		('uint16', 'VarDeltasCount', None, None, ''),
+		('LOffset', 'VarDeltas', 'VarDeltasCount', 0, ''),
+	]),
+
+	#
 	# math
 	#
 

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -845,7 +845,7 @@ otData = [
 	# VariationStore
 
 	('VarAxis', [
-		('uint16', 'VarAxisID', None, None, ''),
+		('VarAxisID', 'VarAxisID', None, None, ''),
 		('F2Dot14', 'StartCoord', None, None, ''),
 		('F2Dot14', 'PeakCoord', None, None, ''),
 		('F2Dot14', 'EndCoord', None, None, ''),
@@ -862,10 +862,10 @@ otData = [
 	]),
 
 	('VarItemByteRecord', [
-		('int8', 'deltas', 'VarTupleCount', 0, ''),
+		('int8', 'Deltas', 'VarTupleCount', 0, ''),
 	]),
 	('VarItemShortRecord', [
-		('int16', 'deltas', 'VarTupleCount', 0, ''),
+		('int16', 'Deltas', 'VarTupleCount', 0, ''),
 	]),
 
 	('VarDeltasFormat1', [

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -837,11 +837,15 @@ otData = [
 		('Offset', 'Lookup', 'LookupCount', 0, 'Array of offsets to GPOS-type lookup tables-from beginning of JstfMax table-in design order'),
 	]),
 
+
 	#
-	# variations
+	# Variation fonts
 	#
+
+	# VariationStore
+
 	('VarAxis', [
-		('uint16', 'AxisIndex', None, None, ''),
+		('uint16', 'VarAxisID', None, None, ''),
 		('F2Dot14', 'StartCoord', None, None, ''),
 		('F2Dot14', 'PeakCoord', None, None, ''),
 		('F2Dot14', 'EndCoord', None, None, ''),
@@ -869,7 +873,7 @@ otData = [
 		('uint16', 'ItemCount', None, None, ''),
 		('uint16', 'VarTupleCount', None, None, ''),
 		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
-		('struct', 'VarItemByteRecord', 'ItemCount', 0, ''),
+		('VarItemByteRecord', 'Item', 'ItemCount', 0, ''),
 	]),
 
 	('VarDeltasFormat2', [
@@ -877,15 +881,42 @@ otData = [
 		('uint16', 'ItemCount', None, None, ''),
 		('uint16', 'VarTupleCount', None, None, ''),
 		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
-		('struct', 'VarItemShortRecord', 'ItemCount', 0, ''),
+		('VarItemShortRecord', 'Item', 'ItemCount', 0, ''),
 	]),
 
 	('VarStore', [
-		('LOffset', 'VarTupleList', None, None, ''),
 		('uint16', 'Format', None, None, 'Set to 1.'),
+		('LOffset', 'VarTupleList', None, None, ''),
 		('uint16', 'VarDeltasCount', None, None, ''),
 		('LOffset', 'VarDeltas', 'VarDeltasCount', 0, ''),
 	]),
+
+	# Variation helpers
+
+	('VarIdxMapFormat1', [
+		('uint16', 'Format', None, None, 'Set to 1.'),
+		('uint16', 'VarIdxCount', None, None, ''),
+		('uint16', 'VarIdx', 'VarIdxCount', 0, ''),
+	]),
+	('VarIdxMapFormat2', [
+		('uint16', 'Format', None, None, 'Set to 2.'),
+		('uint16', 'VarIdxCount', None, None, ''),
+		('uint32', 'VarIdx', 'VarIdxCount', 0, ''),
+	]),
+
+	# Glyph advance variations
+
+	('HVAR', [
+		('Version', 'Version', None, None, 'Version of the HVAR table-initially = 0x00010000'),
+		('LOffset', 'VarIdxMap', None, None, ''),
+		('LOffset', 'VarStore', None, None, ''),
+	]),
+	('VVAR', [
+		('Version', 'Version', None, None, 'Version of the VVAR table-initially = 0x00010000'),
+		('LOffset', 'VarIdxMap', None, None, ''),
+		('LOffset', 'VarStore', None, None, ''),
+	]),
+
 
 	#
 	# math

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -645,6 +645,7 @@ otData = [
 		('Offset', 'LigCaretList', None, None, 'Offset to list of positioning points for ligature carets-from beginning of GDEF header (may be NULL)'),
 		('Offset', 'MarkAttachClassDef', None, None, 'Offset to class definition table for mark attachment type-from beginning of GDEF header (may be NULL)'),
 		('Offset', 'MarkGlyphSetsDef', None, 'int(round(Version*0x10000)) >= 0x00010002', 'Offset to the table of mark set definitions-from beginning of GDEF header (may be NULL)'),
+		('LOffset', 'VarStore', None, 'int(round(Version*0x10000)) >= 0x00010003', 'Offset to variation store (may be NULL)'),
 	]),
 
 	('AttachList', [

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -844,43 +844,42 @@ otData = [
 
 	# VariationStore
 
-	('VarAxis', [
-		('VarAxisID', 'VarAxisID', None, None, ''),
+	('VarRegionAxis', [
 		('F2Dot14', 'StartCoord', None, None, ''),
 		('F2Dot14', 'PeakCoord', None, None, ''),
 		('F2Dot14', 'EndCoord', None, None, ''),
 	]),
 
-	('VarTuple', [
-		('uint16', 'VarAxisCount', None, None, ''),
-		('struct', 'VarAxis', 'VarAxisCount', 0, ''),
+	('VarRegion', [
+		('struct', 'VarRegionAxis', 'RegionAxisCount', 0, ''),
 	]),
 
 	('VarRegionList', [
-		('uint16', 'VarTupleCount', None, None, ''),
-		('LOffset', 'VarTuple', 'VarTupleCount', 0, ''),
+		('uint16', 'RegionAxisCount', None, None, ''),
+		('uint16', 'RegionCount', None, None, ''),
+		('VarRegion', 'Region', 'RegionCount', 0, ''),
 	]),
 
 	('VarItemByteRecord', [
-		('int8', 'Deltas', 'VarTupleCount', 0, ''),
+		('int8', 'Deltas', 'VarRegionCount', 0, ''),
 	]),
 	('VarItemShortRecord', [
-		('int16', 'Deltas', 'VarTupleCount', 0, ''),
+		('int16', 'Deltas', 'VarRegionCount', 0, ''),
 	]),
 
 	('VarDeltasFormat1', [
 		('uint16', 'Format', None, None, 'Set to 1.'),
 		('uint16', 'ItemCount', None, None, ''),
-		('uint16', 'VarTupleCount', None, None, ''),
-		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
+		('uint16', 'VarRegionCount', None, None, ''),
+		('uint16', 'VarRegionIndex', 'VarRegionCount', 0, ''),
 		('VarItemByteRecord', 'Item', 'ItemCount', 0, ''),
 	]),
 
 	('VarDeltasFormat2', [
 		('uint16', 'Format', None, None, 'Set to 2.'),
 		('uint16', 'ItemCount', None, None, ''),
-		('uint16', 'VarTupleCount', None, None, ''),
-		('uint16', 'VarTupleIndex', 'VarTupleCount', 0, ''),
+		('uint16', 'VarRegionCount', None, None, ''),
+		('uint16', 'VarRegionIndex', 'VarRegionCount', 0, ''),
 		('VarItemShortRecord', 'Item', 'ItemCount', 0, ''),
 	]),
 

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -856,7 +856,7 @@ otData = [
 		('struct', 'VarAxis', 'VarAxisCount', 0, ''),
 	]),
 
-	('VarTupleList', [
+	('VarRegionList', [
 		('uint16', 'VarTupleCount', None, None, ''),
 		('LOffset', 'VarTuple', 'VarTupleCount', 0, ''),
 	]),
@@ -886,7 +886,8 @@ otData = [
 
 	('VarStore', [
 		('uint16', 'Format', None, None, 'Set to 1.'),
-		('LOffset', 'VarTupleList', None, None, ''),
+		('uint16', 'Reserved', None, None, 'Set to 0.'),
+		('LOffset', 'VarRegionList', None, None, ''),
 		('uint16', 'VarDeltasCount', None, None, ''),
 		('LOffset', 'VarDeltas', 'VarDeltasCount', 0, ''),
 	]),

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -870,7 +870,6 @@ otData = [
 
 	('VarStore', [
 		('uint16', 'Format', None, None, 'Set to 1.'),
-		('uint16', 'Reserved', None, None, 'Set to 0.'),
 		('LOffset', 'VarRegionList', None, None, ''),
 		('uint16', 'VarDataCount', None, None, ''),
 		('LOffset', 'VarData', 'VarDataCount', 0, ''),

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -6,6 +6,7 @@ otData = [
 	#
 	# common
 	#
+	# type, name, repeat, aux, descr 
 
 	('LookupOrder', []),
 
@@ -443,10 +444,45 @@ otData = [
 	#
 
 	('GSUB', [
-		('Version', 'Version', None, None, 'Version of the GSUB table-initially set to 0x00010000'),
+		('Version', 'Version', None, None, 'Version of the GSUB table-initially set to 0x00010000, or 0x00010000 if supporting FeatureVariations'),
 		('Offset', 'ScriptList', None, None, 'Offset to ScriptList table-from beginning of GSUB table'),
 		('Offset', 'FeatureList', None, None, 'Offset to FeatureList table-from beginning of GSUB table'),
 		('Offset', 'LookupList', None, None, 'Offset to LookupList table-from beginning of GSUB table'),
+		('LOffset', 'FeatureVariations', None, None, 'Offset to FeatureVariations table-from beginning of GSUB table'),
+	]),
+
+	('FeatureVariations', [
+		('uint16', 'Major', None, None, 'Version of the table-initially set to 0x00010000'),
+		('uint16', 'Minor', None, None, 'Version of the table-initially set to 0x00010000'),
+		('uint32', 'FeatureVariationRecordsCount', None, None, 'Number of records in the FeatureVariationRecords array'),
+		('struct', 'FeatureVariationRecord', 'FeatureVariationRecordsCount', 0, 'Array of FeatureVariationRecords'),
+	]),
+
+	('FeatureVariationRecord', [
+		('LOffset', 'ConditionSet', None, None, 'Offset to a ConditionSet table.'),
+		('LOffset', 'FeatureTableSubstitution', None, None, 'Offset to a FeatureTableSubstitution table, from beginning of the FeatureVariations table'),
+	]),
+
+	('ConditionSet', [
+		('uint16', 'ConditionCount', None, None, 'Number of condition tables in the ConditionTable array'),
+		('struct', 'ConditionTable', 'ConditionCount', 0, 'Array of condition tables.'),
+	]),
+
+	('ConditionTable', [
+		('uint16', 'Format', None, None, 'default format'),
+		('uint16', 'AxisIndex', None, None, 'Index for the variation axis within the fvar table, base 0.'),
+		('F2Dot14', 'FilterRangeMinValue', None, None, 'Minimum normalized axis value of the font variation instances that satisfy this condition.'),
+		('F2Dot14', 'FilterRangeMaxValue', None, None, 'Maximum value that satisfies this condition.'),
+	]),
+
+	('FeatureTableSubstitution', [
+		('uint16', 'SubstitutionCount', None, None, 'Number of records in the FeatureVariationRecords array'),
+		('struct', 'FeatureTableSubstitutionRecord', 'SubstitutionCount', 0, 'Array of FeatureTableSubstitutionRecord'),
+	]),
+
+	('FeatureTableSubstitutionRecord', [
+		('uint16', 'FeatureIndex', None, None, 'The feature table index to match.'),
+		('LOffset', 'Feature', None, None, 'Offset to an alternate feature table, from start of the FeatureTableSubstitution table.'),
 	]),
 
 	('SingleSubstFormat1', [
@@ -885,6 +921,9 @@ otData = [
 
 	# Glyph advance variations
 
+	('CFFV', [
+		('VarStore', 'VarStore', None, None, 'CFF variation store'),
+	]),
 	('HVAR', [
 		('Version', 'Version', None, None, 'Version of the HVAR table-initially = 0x00010000'),
 		('LOffset', 'VarStore', None, None, ''),

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -893,28 +893,28 @@ otData = [
 
 	# Variation helpers
 
-	('VarIdxMapFormat1', [
-		('uint16', 'Format', None, None, 'Set to 1.'),
-		('uint16', 'VarIdxCount', None, None, ''),
-		('uint16', 'VarIdx', 'VarIdxCount', 0, ''),
-	]),
-	('VarIdxMapFormat2', [
-		('uint16', 'Format', None, None, 'Set to 2.'),
-		('uint16', 'VarIdxCount', None, None, ''),
-		('uint32', 'VarIdx', 'VarIdxCount', 0, ''),
+	('VarIdxMap', [
+		('uint16', 'EntryFormat', None, None, ''),
+		('uint16', 'MappingCount', None, None, ''),
+		('VarIdxMapValue', 'mapping', '', 0, 'Array of compressed data'),
 	]),
 
 	# Glyph advance variations
 
 	('HVAR', [
 		('Version', 'Version', None, None, 'Version of the HVAR table-initially = 0x00010000'),
-		('LOffset', 'VarIdxMap', None, None, ''),
 		('LOffset', 'VarStore', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'AdvWidthMap', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'LsbMap', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'RsbMap', None, None, ''),
 	]),
 	('VVAR', [
 		('Version', 'Version', None, None, 'Version of the VVAR table-initially = 0x00010000'),
-		('LOffset', 'VarIdxMap', None, None, ''),
 		('LOffset', 'VarStore', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'AdvHeightMap', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'TsbMap', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'BsbMap', None, None, ''),
+		('LOffsetTo(VarIdxMap)', 'VOrgMap', None, None, 'Vertical origin mapping.'),
 	]),
 
 

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -860,35 +860,20 @@ otData = [
 		('VarRegion', 'Region', 'RegionCount', 0, ''),
 	]),
 
-	('VarItemByteRecord', [
-		('int8', 'Deltas', 'VarRegionCount', 0, ''),
-	]),
-	('VarItemShortRecord', [
-		('int16', 'Deltas', 'VarRegionCount', 0, ''),
-	]),
-
-	('VarDeltasFormat1', [
-		('uint16', 'Format', None, None, 'Set to 1.'),
+	('VarData', [
 		('uint16', 'ItemCount', None, None, ''),
+		('uint16', 'NumShorts', None, None, ''),
 		('uint16', 'VarRegionCount', None, None, ''),
 		('uint16', 'VarRegionIndex', 'VarRegionCount', 0, ''),
-		('VarItemByteRecord', 'Item', 'ItemCount', 0, ''),
-	]),
-
-	('VarDeltasFormat2', [
-		('uint16', 'Format', None, None, 'Set to 2.'),
-		('uint16', 'ItemCount', None, None, ''),
-		('uint16', 'VarRegionCount', None, None, ''),
-		('uint16', 'VarRegionIndex', 'VarRegionCount', 0, ''),
-		('VarItemShortRecord', 'Item', 'ItemCount', 0, ''),
+		('VarDataValue', 'Item', 'ItemCount', 0, ''),
 	]),
 
 	('VarStore', [
 		('uint16', 'Format', None, None, 'Set to 1.'),
 		('uint16', 'Reserved', None, None, 'Set to 0.'),
 		('LOffset', 'VarRegionList', None, None, ''),
-		('uint16', 'VarDeltasCount', None, None, ''),
-		('LOffset', 'VarDeltas', 'VarDeltasCount', 0, ''),
+		('uint16', 'VarDataCount', None, None, ''),
+		('LOffset', 'VarData', 'VarDataCount', 0, ''),
 	]),
 
 	# Variation helpers

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -862,7 +862,7 @@ otData = [
 
 	('VarData', [
 		('uint16', 'ItemCount', None, None, ''),
-		('uint16', 'NumShorts', None, None, ''),
+		('uint16', 'NumShorts', None, None, ''), # Automatically computed
 		('uint16', 'VarRegionCount', None, None, ''),
 		('uint16', 'VarRegionIndex', 'VarRegionCount', 0, ''),
 		('VarDataValue', 'Item', 'ItemCount', 0, ''),
@@ -879,8 +879,8 @@ otData = [
 	# Variation helpers
 
 	('VarIdxMap', [
-		('uint16', 'EntryFormat', None, None, ''),
-		('uint16', 'MappingCount', None, None, ''),
+		('uint16', 'EntryFormat', None, None, ''), # Automatically computed
+		('uint16', 'MappingCount', None, None, ''), # Automatically computed
 		('VarIdxMapValue', 'mapping', '', 0, 'Array of compressed data'),
 	]),
 

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -193,11 +193,14 @@ class VarData(BaseTable):
 		rawTable = self.__dict__.copy()
 
 		numShorts = 0
+		count = self.VarRegionCount
 		for item in self.Item:
-			for i in range(len(item) - 1, numShorts - 1, -1):
+			for i in range(count - 1, numShorts - 1, -1):
 				if not (-128 <= item[i] <= 127):
 					numShorts = i + 1
 					break
+			if numShorts == count:
+				break
 
 		rawTable['NumShorts'] = numShorts
 		return rawTable

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -187,6 +187,22 @@ class VarIdxMap(BaseTable):
 		mapping.append(safeEval(attrs["value"]))
 
 
+class VarData(BaseTable):
+
+	def preWrite(self, font):
+		rawTable = self.__dict__.copy()
+
+		numShorts = 0
+		for item in self.Item:
+			for i in range(len(item) - 1, numShorts - 1, -1):
+				if not (-128 <= item[i] <= 127):
+					numShorts = i + 1
+					break
+
+		rawTable['NumShorts'] = numShorts
+		return rawTable
+
+
 class SingleSubst(FormatSwitchingBaseTable):
 
 	def postRead(self, rawTable, font):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -25,6 +25,7 @@ from fontTools.ttLib.tables._n_a_m_e import NameRecord
 from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r, Axis, NamedInstance
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r, GlyphVariation
+from fontTools.varLib import builder
 import warnings
 try:
 	import xml.etree.cElementTree as ET

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -495,8 +495,9 @@ def _add_HVAR(font, model, master_ttfs):
 	HVAR = font["HVAR"] = newTable('HVAR')
 	hvar = HVAR.table = ot.HVAR()
 	hvar.Version = 1.0
-	hvar.VarIdxMap = None
 	hvar.VarStore = varStore
+
+	#hvar.AdvWidthMap = builder.buildVarIdxMap(mapping)
 
 
 def main(args=None):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -479,7 +479,7 @@ def _add_HVAR(font, model, master_ttfs):
 	# We only support the direct mapping right now.
 
 	supports = model.supports[1:]
-	varTupleList = builder.buildVarTupleList(supports)
+	varTupleList = builder.buildVarRegionList(supports)
 	varTupleIndexes = list(range(len(supports)))
 	n = len(supports)
 	items = []

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -489,9 +489,18 @@ def _add_HVAR(font, model, master_ttfs, axes):
 	while items and items[-1] is zeroes:
 		del items[-1]
 
-	# TODO Add indirect mapping to save on duplicates
-	#uniq = set(items)
-	#if (len(items) - len(uniq)) * len(varTupleIndexs)) > len(items) * 2:
+	advanceMapping = None
+	# Add indirect mapping to save on duplicates
+	uniq = set(items)
+	# TODO Improve heuristic
+	if (len(items) - len(uniq)) * len(varTupleIndexes) > len(items):
+		newItems = sorted(uniq)
+		mapper = {v:i for i,v in enumerate(newItems)}
+		mapping = [mapper[item] for item in items]
+		advanceMapping = builder.buildVarIdxMap(mapping)
+		items = newItems
+		del mapper, mapping, newItems
+	del uniq
 
 	varData = builder.buildVarData(varTupleIndexes, items)
 	varStore = builder.buildVarStore(varTupleList, [varData])
@@ -501,8 +510,8 @@ def _add_HVAR(font, model, master_ttfs, axes):
 	hvar = HVAR.table = ot.HVAR()
 	hvar.Version = 1.0
 	hvar.VarStore = varStore
-
-	#hvar.AdvWidthMap = builder.buildVarIdxMap(mapping)
+	hvar.AdvWidthMap = advanceMapping
+	hvar.LsbMap = hvar.RsbMap = None
 
 
 def main(args=None):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -488,6 +488,11 @@ def _add_HVAR(font, model, master_ttfs, axes):
 		items.append(hAdvanceDeltas.get(glyphName, zeroes))
 	while items and items[-1] is zeroes:
 		del items[-1]
+
+	# TODO Add indirect mapping to save on duplicates
+	#uniq = set(items)
+	#if (len(items) - len(uniq)) * len(varTupleIndexs)) > len(items) * 2:
+
 	varData = builder.buildVarData(varTupleIndexes, items)
 	varStore = builder.buildVarStore(varTupleList, [varData])
 

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -488,8 +488,8 @@ def _add_HVAR(font, model, master_ttfs, axes):
 		items.append(hAdvanceDeltas.get(glyphName, zeroes))
 	while items and items[-1] is zeroes:
 		del items[-1]
-	varDeltas = builder.buildVarDeltas(varTupleIndexes, items)
-	varStore = builder.buildVarStore(varTupleList, [varDeltas])
+	varData = builder.buildVarData(varTupleIndexes, items)
+	varStore = builder.buildVarStore(varTupleList, [varData])
 
 	assert "HVAR" not in font
 	HVAR = font["HVAR"] = newTable('HVAR')
@@ -591,7 +591,7 @@ def main(args=None):
 	model = _build_model(axes, master_locs, base_idx)
 
 	print("Building variations tables")
-	_add_gvar(gx, model, master_fonts)
+	#_add_gvar(gx, model, master_fonts)
 	_add_HVAR(gx, model, master_fonts, axes)
 
 	print("Saving GX font", outfile)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -466,7 +466,7 @@ def _add_gvar(font, model, master_ttfs):
 			var = GlyphVariation(support, delta)
 			gvar.variations[glyph].append(var)
 
-def _add_HVAR(font, model, master_ttfs):
+def _add_HVAR(font, model, master_ttfs, axes):
 
 	print("Generating HVAR")
 
@@ -479,7 +479,7 @@ def _add_HVAR(font, model, master_ttfs):
 	# We only support the direct mapping right now.
 
 	supports = model.supports[1:]
-	varTupleList = builder.buildVarRegionList(supports)
+	varTupleList = builder.buildVarRegionList(supports, axes.keys())
 	varTupleIndexes = list(range(len(supports)))
 	n = len(supports)
 	items = []
@@ -592,7 +592,7 @@ def main(args=None):
 
 	print("Building variations tables")
 	_add_gvar(gx, model, master_fonts)
-	_add_HVAR(gx, model, master_fonts)
+	_add_HVAR(gx, model, master_fonts, axes)
 
 	print("Saving GX font", outfile)
 	gx.save(outfile)

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -28,22 +28,23 @@ def buildVarTupleList(supports):
 
 def buildVarDeltas(varTupleIndexes, items):
 	self = ot.VarDeltas()
-	self.format = 1 if all(all(128 <= delta <= 127 for delta in item) for item in items) else 2
+	self.Format = 1 if all(all(128 <= delta <= 127 for delta in item) for item in items) else 2
 	self.VarTupleIndex = list(varTupleIndexes)
 	tupleCount = self.VarTupleCount = len(self.VarTupleIndex)
 	records = self.Item = []
 	for item in items:
 		assert len(item) == tupleCount
-		record = ot.VarItemByteRecord() if self.format == 1 else ot.VarItemShortRecord()
-		record.deltas = list(item)
+		record = ot.VarItemByteRecord() if self.Format == 1 else ot.VarItemShortRecord()
+		record.Deltas = list(item)
 		records.append(record)
 	self.ItemCount = len(self.Item)
 	return self
 
-def buildVarStore(varTupleList, varDeltas):
+def buildVarStore(varTupleList, varDeltasList):
 	self = ot.VarStore()
+	self.Format = 1
 	self.VarTupleList = varTupleList
-	self.VarDeltas = varDeltas
+	self.VarDeltas = list(varDeltasList)
 	self.VarDeltasCount = len(self.VarDeltas)
 	return self
 

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -1,0 +1,57 @@
+from __future__ import print_function, division, absolute_import
+from fontTools import ttLib
+from fontTools.ttLib.tables import otTables as ot
+
+# VariationStore
+
+def buildVarAxis(axisTag, axisSupport):
+	self = ot.VarAxis()
+	self.VarAxisID = axisTag
+	self.StartCoord, self.PeakCoord, self.EndCoord = axisSupport
+	return self
+
+def buildVarTuple(support):
+	self = ot.VarTuple()
+	self.VarAxis = []
+	for axisTag in sorted(support.keys()): # TODO order by axisIdx instead of tag?!
+		self.VarAxis.append(buildVarAxis(axisTag, support[axisTag]))
+	self.VarAxisCount = len(self.VarAxis)
+	return self
+
+def buildVarTupleList(supports):
+	self = ot.VarTupleList()
+	self.VarTuple = []
+	for support in supports:
+		self.VarTuple.append(buildVarTuple(support))
+	self.VarTupleCount = len(self.VarTuple)
+	return self
+
+def buildVarDeltas(varTupleIndexes, items):
+	self = ot.VarDeltas()
+	self.format = 1 if all(all(128 <= delta <= 127 for delta in item) for item in items) else 2
+	self.VarTupleIndex = list(varTupleIndexes)
+	tupleCount = self.VarTupleCount = len(self.VarTupleIndex)
+	records = self.Item = []
+	for item in items:
+		assert len(item) == tupleCount
+		record = ot.VarItemByteRecord() if self.format == 1 else ot.VarItemShortRecord()
+		record.deltas = list(item)
+		records.append(record)
+	self.ItemCount = len(self.Item)
+	return self
+
+def buildVarStore(varTupleList, varDeltas):
+	self = ot.VarStore()
+	self.VarTupleList = varTupleList
+	self.VarDeltas = varDeltas
+	self.VarDeltasCount = len(self.VarDeltas)
+	return self
+
+# Variation helpers
+
+def buildVarIdxMap(varIdxes):
+	self = ot.VarIdxMap()
+	self.VarIdx = varIdxes = list(varIdxes)
+	self.VarIdxCount = len(self.VarIdx)
+	self.Format = 1 if all(x <= 0xFFFF for x in varIdxes) else 2
+	return self

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -20,10 +20,10 @@ def buildVarRegion(support, axisTags):
 def buildVarRegionList(supports, axisTags):
 	self = ot.VarRegionList()
 	self.AxisCount = len(axisTags)
-	self.VarRegion = []
+	self.Region = []
 	for support in supports:
-		self.VarRegion.append(buildVarRegion(support, axisTags))
-	self.VarRegionCount = len(self.VarRegion)
+		self.Region.append(buildVarRegion(support, axisTags))
+	self.RegionCount = len(self.Region)
 	return self
 
 
@@ -54,7 +54,6 @@ def optimizeVarData(self):
 	self.VarRegionIndex = _reorderItem(self.VarRegionIndex, narrows)
 	for i in range(self.ItemCount):
 		items[i] = _reorderItem(items[i], narrows)
-
 	return self
 
 def buildVarData(varRegionIndices, items, optimize=True):
@@ -62,19 +61,19 @@ def buildVarData(varRegionIndices, items, optimize=True):
 	self.VarRegionIndex = list(varRegionIndices)
 	regionCount = self.VarRegionCount = len(self.VarRegionIndex)
 	records = self.Item = []
-	for item in items:
-		assert len(item) == regionCount
-		records.append(list(item))
-	self.ItemCount = len(self.Item)
-	if optimize:
-		optimizeVarData(self)
+	if items!= None:
+		for item in items:
+			assert len(item) == regionCount
+			records.append(list(item))
+		self.ItemCount = len(self.Item)
+		if optimize:
+			optimizeVarData(self)
 	return self
 
 
 def buildVarStore(varTupleList, varDataList):
 	self = ot.VarStore()
 	self.Format = 1
-	self.Reserved = 0
 	self.VarRegionList = varTupleList
 	self.VarData = list(varDataList)
 	self.VarDataCount = len(self.VarData)

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -52,7 +52,5 @@ def buildVarStore(varTupleList, varDeltasList):
 
 def buildVarIdxMap(varIdxes):
 	self = ot.VarIdxMap()
-	self.VarIdx = varIdxes = list(varIdxes)
-	self.VarIdxCount = len(self.VarIdx)
-	self.Format = 1 if all(x <= 0xFFFF for x in varIdxes) else 2
+	self.mapping = list(varIdxes)
 	return self

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -26,7 +26,38 @@ def buildVarRegionList(supports, axisTags):
 	self.VarRegionCount = len(self.VarRegion)
 	return self
 
-def buildVarData(varRegionIndices, items):
+
+def _reorderItem(lst, narrows):
+	out = []
+	count = len(lst)
+	for i in range(count):
+		if i not in narrows:
+			out.append(lst[i])
+	for i in range(count):
+		if i in narrows:
+			out.append(lst[i])
+	return out
+
+def optimizeVarData(self):
+	# Reorder columns such that all SHORT columns come before UINT8
+	count = self.VarRegionCount
+	items = self.Item
+	narrows = set(range(count))
+	for item in items:
+		for i in narrows:
+			if not (-128 <= item[i] <= 127):
+				narrows.remove(i)
+				break
+		if not narrows:
+			break
+
+	self.VarRegionIndex = _reorderItem(self.VarRegionIndex, narrows)
+	for i in range(self.ItemCount):
+		items[i] = _reorderItem(items[i], narrows)
+
+	return self
+
+def buildVarData(varRegionIndices, items, optimize=True):
 	self = ot.VarData()
 	self.VarRegionIndex = list(varRegionIndices)
 	regionCount = self.VarRegionCount = len(self.VarRegionIndex)
@@ -35,7 +66,10 @@ def buildVarData(varRegionIndices, items):
 		assert len(item) == regionCount
 		records.append(list(item))
 	self.ItemCount = len(self.Item)
+	if optimize:
+		optimizeVarData(self)
 	return self
+
 
 def buildVarStore(varTupleList, varDataList):
 	self = ot.VarStore()

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -4,33 +4,33 @@ from fontTools.ttLib.tables import otTables as ot
 
 # VariationStore
 
-def buildVarAxis(axisTag, axisSupport):
-	self = ot.VarAxis()
-	self.VarAxisID = axisTag
+def buildVarRegionAxis(axisSupport):
+	self = ot.VarRegionAxis()
 	self.StartCoord, self.PeakCoord, self.EndCoord = axisSupport
 	return self
 
-def buildVarTuple(support):
-	self = ot.VarTuple()
-	self.VarAxis = []
-	for axisTag in sorted(support.keys()): # TODO order by axisIdx instead of tag?!
-		self.VarAxis.append(buildVarAxis(axisTag, support[axisTag]))
-	self.VarAxisCount = len(self.VarAxis)
+def buildVarRegion(support, axisTags):
+	self = ot.VarRegion()
+	self.VarRegionAxis = []
+	for tag in axisTags:
+		self.VarRegionAxis.append(buildVarRegionAxis(support.get(tag, (0,0,0))))
+	self.VarRegionAxisCount = len(self.VarRegionAxis)
 	return self
 
-def buildVarRegionList(supports):
+def buildVarRegionList(supports, axisTags):
 	self = ot.VarRegionList()
-	self.VarTuple = []
+	self.AxisCount = len(axisTags)
+	self.VarRegion = []
 	for support in supports:
-		self.VarTuple.append(buildVarTuple(support))
-	self.VarTupleCount = len(self.VarTuple)
+		self.VarRegion.append(buildVarRegion(support, axisTags))
+	self.VarRegionCount = len(self.VarRegion)
 	return self
 
 def buildVarDeltas(varTupleIndexes, items):
 	self = ot.VarDeltas()
 	self.Format = 1 if all(all(128 <= delta <= 127 for delta in item) for item in items) else 2
-	self.VarTupleIndex = list(varTupleIndexes)
-	tupleCount = self.VarTupleCount = len(self.VarTupleIndex)
+	self.VarRegionIndex = list(varTupleIndexes)
+	tupleCount = self.VarRegionCount = len(self.VarRegionIndex)
 	records = self.Item = []
 	for item in items:
 		assert len(item) == tupleCount

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -26,27 +26,25 @@ def buildVarRegionList(supports, axisTags):
 	self.VarRegionCount = len(self.VarRegion)
 	return self
 
-def buildVarDeltas(varTupleIndexes, items):
-	self = ot.VarDeltas()
-	self.Format = 1 if all(all(128 <= delta <= 127 for delta in item) for item in items) else 2
-	self.VarRegionIndex = list(varTupleIndexes)
-	tupleCount = self.VarRegionCount = len(self.VarRegionIndex)
+def buildVarData(varRegionIndices, items):
+	self = ot.VarData()
+	self.VarRegionIndex = list(varRegionIndices)
+	regionCount = self.VarRegionCount = len(self.VarRegionIndex)
 	records = self.Item = []
 	for item in items:
-		assert len(item) == tupleCount
-		record = ot.VarItemByteRecord() if self.Format == 1 else ot.VarItemShortRecord()
-		record.Deltas = list(item)
-		records.append(record)
+		assert len(item) == regionCount
+		records.append(list(item))
 	self.ItemCount = len(self.Item)
+	self.NumShorts = self.VarRegionCount # XXX
 	return self
 
-def buildVarStore(varTupleList, varDeltasList):
+def buildVarStore(varTupleList, varDataList):
 	self = ot.VarStore()
 	self.Format = 1
 	self.Reserved = 0
 	self.VarRegionList = varTupleList
-	self.VarDeltas = list(varDeltasList)
-	self.VarDeltasCount = len(self.VarDeltas)
+	self.VarData = list(varDataList)
+	self.VarDataCount = len(self.VarData)
 	return self
 
 # Variation helpers

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -18,8 +18,8 @@ def buildVarTuple(support):
 	self.VarAxisCount = len(self.VarAxis)
 	return self
 
-def buildVarTupleList(supports):
-	self = ot.VarTupleList()
+def buildVarRegionList(supports):
+	self = ot.VarRegionList()
 	self.VarTuple = []
 	for support in supports:
 		self.VarTuple.append(buildVarTuple(support))
@@ -43,7 +43,8 @@ def buildVarDeltas(varTupleIndexes, items):
 def buildVarStore(varTupleList, varDeltasList):
 	self = ot.VarStore()
 	self.Format = 1
-	self.VarTupleList = varTupleList
+	self.Reserved = 0
+	self.VarRegionList = varTupleList
 	self.VarDeltas = list(varDeltasList)
 	self.VarDeltasCount = len(self.VarDeltas)
 	return self

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -35,7 +35,6 @@ def buildVarData(varRegionIndices, items):
 		assert len(item) == regionCount
 		records.append(list(item))
 	self.ItemCount = len(self.Item)
-	self.NumShorts = self.VarRegionCount # XXX
 	return self
 
 def buildVarStore(varTupleList, varDataList):

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -45,6 +45,7 @@ def main(args=None):
 		else:
 			v = (v - default) / (upper - default)
 		loc[axis.axisTag] = v
+	# Round to F2Dot14
 	# Location is normalized now
 	print("Normalized location:", loc)
 

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -45,7 +45,7 @@ def main(args=None):
 		else:
 			v = (v - default) / (upper - default)
 		loc[axis.axisTag] = v
-	# Round to F2Dot14
+	# TODO Round to F2Dot14
 	# Location is normalized now
 	print("Normalized location:", loc)
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ These additional options include:
 The following tables are currently supported:
 <!-- begin table list -->
     BASE, CBDT, CBLC, CFF, COLR, CPAL, DSIG, EBDT, EBLC, FFTM, GDEF,
-    GMAP, GPKG, GPOS, GSUB, JSTF, LTSH, MATH, META, OS/2, SING, SVG,
-    TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS, TSIV,
-    VDMX, VORG, avar, cmap, cvt, feat, fpgm, fvar, gasp, glyf, gvar,
-    hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, meta, name, post,
-    prep, sbix, trak, vhea and vmtx
+    GMAP, GPKG, GPOS, GSUB, HVAR, JSTF, LTSH, MATH, META, OS/2, SING,
+    SVG, TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSID, TSIJ, TSIP, TSIS,
+    TSIV, VDMX, VORG, VVAR, avar, cmap, cvt, feat, fpgm, fvar, gasp,
+    glyf, gvar, hdmx, head, hhea, hmtx, kern, loca, ltag, maxp, meta,
+    name, post, prep, sbix, trak, vhea and vmtx
 <!-- end table list -->
 Other tables are dumped as hexadecimal data.
 


### PR DESCRIPTION
varlib/builder.py:
Fix mis-match in structure names with otData.py: VarRegion
Remove outdated field: self.Reserved
Handle item == None

varlib/__init__.py
Use postscript name entry from designspace file
Add Windows name ID entries as well as Mac name ID entries.
Add logic for making CFFV table rather than gvar when source master font has CFF instead of glyf. Although CFFV table is deprecated as an OpenType top level table, the CFFV table is is still used in the CFF23 table.

ttlib/tables/__init__.py
Add CFF2 and CFFV. Latter is still useful as an intermediate step.

ttlib/tables/_f_v_a_r.py
Support instance postscript name ID. Change name od nameid to subfamilyNameID to distinguish from ps name id.

ttlib/tables/otBase.py
Support long offsets.

ttlib/tables/otConverters.py
Support long computed counts.

ttlib/tables/otData.py
Add structures needed for GSUB FeatureVariations subtable.

cffLib.py
Changes to support CFF2. Note that this is work in progress: the current version does not remove all the CFF data structures that have been removed from the OT CFF2 spec.

misc/psCharStrings.py
Changes to support CFF2.

