### PR TITLE
[py23] add round2 and round3 functions

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -7,7 +7,7 @@ import sys
 __all__ = ['basestring', 'unicode', 'unichr', 'byteord', 'bytechr', 'BytesIO',
 		'StringIO', 'UnicodeIO', 'strjoin', 'bytesjoin', 'tobytes', 'tostr',
 		'tounicode', 'Tag', 'open', 'range', 'xrange', 'round2', 'round3',
-		'Py23Error']
+		'round', 'Py23Error']
 
 
 class Py23Error(NotImplementedError):

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -6,8 +6,7 @@ import sys
 
 __all__ = ['basestring', 'unicode', 'unichr', 'byteord', 'bytechr', 'BytesIO',
 		'StringIO', 'UnicodeIO', 'strjoin', 'bytesjoin', 'tobytes', 'tostr',
-		'tounicode', 'Tag', 'open', 'range', 'xrange', 'round2', 'round3',
-		'round', 'Py23Error']
+		'tounicode', 'Tag', 'open', 'range', 'xrange', 'round', 'Py23Error']
 
 
 class Py23Error(NotImplementedError):

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -14,6 +14,10 @@ class Py23Error(NotImplementedError):
 	pass
 
 
+PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
+
+
 try:
 	basestring = basestring
 except NameError:
@@ -335,6 +339,13 @@ def round3(number, ndigits=None):
 			exponent, rounding=_decimal.ROUND_HALF_EVEN)
 
 	return int(d) if return_int else float(d)
+
+
+if PY2:
+	round = round3
+else:
+	import builtins
+	round = builtins.round
 
 
 import logging

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -65,5 +65,188 @@ class OpenFuncWrapperTest(unittest.TestCase):
 		self.assertEqual(result, expected)
 
 
+class Round2Test(unittest.TestCase):
+	"""
+	Test cases taken from cpython 2.7 test suite:
+
+	https://github.com/python/cpython/blob/2.7/Lib/test/test_float.py#L748
+
+	Excludes the test cases that are not supported when using the `decimal`
+	module's `quantize` method.
+	"""
+
+	def test_second_argument_type(self):
+		# any type with an __index__ method should be permitted as
+		# a second argument
+		self.assertAlmostEqual(round2(12.34, True), 12.3)
+
+		class MyIndex(object):
+			def __index__(self): return 4
+		self.assertAlmostEqual(round2(-0.123456, MyIndex()), -0.1235)
+		# but floats should be illegal
+		self.assertRaises(TypeError, round2, 3.14159, 2.0)
+
+	def test_halfway_cases(self):
+		# Halfway cases need special attention, since the current
+		# implementation has to deal with them specially.  Note that
+		# 2.x rounds halfway values up (i.e., away from zero) while
+		# 3.x does round-half-to-even.
+		self.assertAlmostEqual(round2(0.125, 2), 0.13)
+		self.assertAlmostEqual(round2(0.375, 2), 0.38)
+		self.assertAlmostEqual(round2(0.625, 2), 0.63)
+		self.assertAlmostEqual(round2(0.875, 2), 0.88)
+		self.assertAlmostEqual(round2(-0.125, 2), -0.13)
+		self.assertAlmostEqual(round2(-0.375, 2), -0.38)
+		self.assertAlmostEqual(round2(-0.625, 2), -0.63)
+		self.assertAlmostEqual(round2(-0.875, 2), -0.88)
+
+		self.assertAlmostEqual(round2(0.25, 1), 0.3)
+		self.assertAlmostEqual(round2(0.75, 1), 0.8)
+		self.assertAlmostEqual(round2(-0.25, 1), -0.3)
+		self.assertAlmostEqual(round2(-0.75, 1), -0.8)
+
+		self.assertEqual(round2(-6.5, 0), -7.0)
+		self.assertEqual(round2(-5.5, 0), -6.0)
+		self.assertEqual(round2(-1.5, 0), -2.0)
+		self.assertEqual(round2(-0.5, 0), -1.0)
+		self.assertEqual(round2(0.5, 0), 1.0)
+		self.assertEqual(round2(1.5, 0), 2.0)
+		self.assertEqual(round2(2.5, 0), 3.0)
+		self.assertEqual(round2(3.5, 0), 4.0)
+		self.assertEqual(round2(4.5, 0), 5.0)
+		self.assertEqual(round2(5.5, 0), 6.0)
+		self.assertEqual(round2(6.5, 0), 7.0)
+
+		# same but without an explicit second argument; in 3.x these
+		# will give integers
+		self.assertEqual(round2(-6.5), -7.0)
+		self.assertEqual(round2(-5.5), -6.0)
+		self.assertEqual(round2(-1.5), -2.0)
+		self.assertEqual(round2(-0.5), -1.0)
+		self.assertEqual(round2(0.5), 1.0)
+		self.assertEqual(round2(1.5), 2.0)
+		self.assertEqual(round2(2.5), 3.0)
+		self.assertEqual(round2(3.5), 4.0)
+		self.assertEqual(round2(4.5), 5.0)
+		self.assertEqual(round2(5.5), 6.0)
+		self.assertEqual(round2(6.5), 7.0)
+
+		self.assertEqual(round2(-25.0, -1), -30.0)
+		self.assertEqual(round2(-15.0, -1), -20.0)
+		self.assertEqual(round2(-5.0, -1), -10.0)
+		self.assertEqual(round2(5.0, -1), 10.0)
+		self.assertEqual(round2(15.0, -1), 20.0)
+		self.assertEqual(round2(25.0, -1), 30.0)
+		self.assertEqual(round2(35.0, -1), 40.0)
+		self.assertEqual(round2(45.0, -1), 50.0)
+		self.assertEqual(round2(55.0, -1), 60.0)
+		self.assertEqual(round2(65.0, -1), 70.0)
+		self.assertEqual(round2(75.0, -1), 80.0)
+		self.assertEqual(round2(85.0, -1), 90.0)
+		self.assertEqual(round2(95.0, -1), 100.0)
+		self.assertEqual(round2(12325.0, -1), 12330.0)
+		self.assertEqual(round2(0, -1), 0.0)
+
+		self.assertEqual(round2(350.0, -2), 400.0)
+		self.assertEqual(round2(450.0, -2), 500.0)
+
+		self.assertAlmostEqual(round2(0.5e21, -21), 1e21)
+		self.assertAlmostEqual(round2(1.5e21, -21), 2e21)
+		self.assertAlmostEqual(round2(2.5e21, -21), 3e21)
+		self.assertAlmostEqual(round2(5.5e21, -21), 6e21)
+		self.assertAlmostEqual(round2(8.5e21, -21), 9e21)
+
+		self.assertAlmostEqual(round2(-1.5e22, -22), -2e22)
+		self.assertAlmostEqual(round2(-0.5e22, -22), -1e22)
+		self.assertAlmostEqual(round2(0.5e22, -22), 1e22)
+		self.assertAlmostEqual(round2(1.5e22, -22), 2e22)
+
+
+class Round3Test(unittest.TestCase):
+	""" Same as above but results adapted for Python 3 round() """
+
+	def test_second_argument_type(self):
+		# any type with an __index__ method should be permitted as
+		# a second argument
+		self.assertAlmostEqual(round3(12.34, True), 12.3)
+
+		class MyIndex(object):
+			def __index__(self): return 4
+		self.assertAlmostEqual(round3(-0.123456, MyIndex()), -0.1235)
+		# but floats should be illegal
+		self.assertRaises(TypeError, round3, 3.14159, 2.0)
+
+	def test_halfway_cases(self):
+		self.assertAlmostEqual(round3(0.125, 2), 0.12)
+		self.assertAlmostEqual(round3(0.375, 2), 0.38)
+		self.assertAlmostEqual(round3(0.625, 2), 0.62)
+		self.assertAlmostEqual(round3(0.875, 2), 0.88)
+		self.assertAlmostEqual(round3(-0.125, 2), -0.12)
+		self.assertAlmostEqual(round3(-0.375, 2), -0.38)
+		self.assertAlmostEqual(round3(-0.625, 2), -0.62)
+		self.assertAlmostEqual(round3(-0.875, 2), -0.88)
+
+		self.assertAlmostEqual(round3(0.25, 1), 0.2)
+		self.assertAlmostEqual(round3(0.75, 1), 0.8)
+		self.assertAlmostEqual(round3(-0.25, 1), -0.2)
+		self.assertAlmostEqual(round3(-0.75, 1), -0.8)
+
+		self.assertEqual(round3(-6.5, 0), -6.0)
+		self.assertEqual(round3(-5.5, 0), -6.0)
+		self.assertEqual(round3(-1.5, 0), -2.0)
+		self.assertEqual(round3(-0.5, 0), 0.0)
+		self.assertEqual(round3(0.5, 0), 0.0)
+		self.assertEqual(round3(1.5, 0), 2.0)
+		self.assertEqual(round3(2.5, 0), 2.0)
+		self.assertEqual(round3(3.5, 0), 4.0)
+		self.assertEqual(round3(4.5, 0), 4.0)
+		self.assertEqual(round3(5.5, 0), 6.0)
+		self.assertEqual(round3(6.5, 0), 6.0)
+
+		# same but without an explicit second argument; in 2.x these
+		# will give floats
+		self.assertEqual(round3(-6.5), -6)
+		self.assertEqual(round3(-5.5), -6)
+		self.assertEqual(round3(-1.5), -2.0)
+		self.assertEqual(round3(-0.5), 0)
+		self.assertEqual(round3(0.5), 0)
+		self.assertEqual(round3(1.5), 2)
+		self.assertEqual(round3(2.5), 2)
+		self.assertEqual(round3(3.5), 4)
+		self.assertEqual(round3(4.5), 4)
+		self.assertEqual(round3(5.5), 6)
+		self.assertEqual(round3(6.5), 6)
+
+		self.assertEqual(round3(-25.0, -1), -20.0)
+		self.assertEqual(round3(-15.0, -1), -20.0)
+		self.assertEqual(round3(-5.0, -1), 0.0)
+		self.assertEqual(round3(5.0, -1), 0.0)
+		self.assertEqual(round3(15.0, -1), 20.0)
+		self.assertEqual(round3(25.0, -1), 20.0)
+		self.assertEqual(round3(35.0, -1), 40.0)
+		self.assertEqual(round3(45.0, -1), 40.0)
+		self.assertEqual(round3(55.0, -1), 60.0)
+		self.assertEqual(round3(65.0, -1), 60.0)
+		self.assertEqual(round3(75.0, -1), 80.0)
+		self.assertEqual(round3(85.0, -1), 80.0)
+		self.assertEqual(round3(95.0, -1), 100.0)
+		self.assertEqual(round3(12325.0, -1), 12320.0)
+		self.assertEqual(round3(0, -1), 0.0)
+
+		self.assertEqual(round3(350.0, -2), 400.0)
+		self.assertEqual(round3(450.0, -2), 400.0)
+
+		self.assertAlmostEqual(round3(0.5e21, -21), 0.0)
+		self.assertAlmostEqual(round3(1.5e21, -21), 2e21)
+		self.assertAlmostEqual(round3(2.5e21, -21), 2e21)
+		self.assertAlmostEqual(round3(5.5e21, -21), 6e21)
+		self.assertAlmostEqual(round3(8.5e21, -21), 8e21)
+
+		self.assertAlmostEqual(round3(-1.5e22, -22), -2e22)
+		self.assertAlmostEqual(round3(-0.5e22, -22), 0.0)
+		self.assertAlmostEqual(round3(0.5e22, -22), 0.0)
+		self.assertAlmostEqual(round3(1.5e22, -22), 2e22)
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -8,6 +8,8 @@ import sys
 import os
 import unittest
 
+from fontTools.misc.py23 import round2, round3
+
 
 PIPE_SCRIPT = """\
 import sys


### PR DESCRIPTION
This is to address https://github.com/behdad/fonttools/issues/664.

It adds two new functions to the `py23` module: namely, `round2` and `round3`.
The former behaves like Python 2's built-in `round` function, wheres the latter like Python 3's.

I also added some of the tests from the CPython 2.7 test suite.

Please review, thanks.

/cc @moyogo 