### PR TITLE
TSI5: set group to 0 (i.e. "AnyGroup") when compiling if glyph name is missing

### DIFF
--- a/Lib/fontTools/ttLib/tables/T_S_I__5.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__5.py
@@ -23,7 +23,7 @@ class table_T_S_I__5(DefaultTable.DefaultTable):
 		glyphNames = ttFont.getGlyphOrder()
 		a = array.array("H")
 		for i in range(len(glyphNames)):
-			a.append(self.glyphGrouping[glyphNames[i]])
+			a.append(self.glyphGrouping.get(glyphNames[i], 0))
 		if sys.byteorder != "big":
 			a.byteswap()
 		return a.tostring()


### PR DESCRIPTION
This is also what VTT does when one does "Prepare font..." and a character is not present in the character groups template file ("CharGrp.txt"): it gets assigned to the default "AnyGroup" group, or 0.

Note that the TSI1 and TSI3 tables do not raise when a glyph name is in the glyphOrder but is missing in their internal mapping; they instead write an empty entry.

This makes easier to merge TSI* tables from different fonts or from earlier revision of the same font containing only a subset of the glyphs.

/cc @moyogo 